### PR TITLE
feat: 버튼 컴포넌트 및 버튼 타입 (#56/#55)

### DIFF
--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import React from 'react';
+import Link from 'next/link';
+import { ButtonProps } from '../../types/buttonType';
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    {
+      href,
+      variant = 'primary',
+      size = 'md',
+      loading = false,
+      fullWidth = false,
+      disabled,
+      children,
+      className = '',
+      ...props
+    },
+    ref
+  ) => {
+    const baseStyles =
+      'rounded-xl transition-all duration-200 ease-in-out disabled:cursor-not-allowed cursor-pointer';
+
+    const variantStyles = {
+      primary:
+        loading || disabled
+          ? 'bg-grayscale-300 text-white'
+          : 'bg-primary-200 text-white hover:bg-primary-300 active:bg-primary-300',
+      secondary:
+        loading || disabled
+          ? 'bg-transparent border-2 border-grayscale-300 text-grayscale-300'
+          : 'bg-transparent border-2 border-primary-200 text-primary-200 hover:bg-primary-100 active:bg-primary-100',
+    };
+
+    const sizeStyles = {
+      sm: 'px-6 py-3 text-md-medium min-w-[120px]',
+      md: 'px-8 py-3.5 text-lg-medium min-w-[160px]',
+      lg: 'px-10 py-4 text-lg-semibold min-w-full',
+    };
+
+    const widthStyles = fullWidth ? 'w-full' : '';
+
+    const combinedClassName = `${baseStyles} ${variantStyles[variant]} ${sizeStyles[size]} ${widthStyles} ${className}`;
+
+    if (href) {
+      const handleClick = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+        if (disabled || loading) {
+          e.preventDefault();
+          return;
+        }
+        const event = e as unknown as React.MouseEvent<HTMLButtonElement, MouseEvent>;
+        props.onClick?.(event);
+      };
+
+      return (
+        <Link
+          ref={ref as React.Ref<HTMLAnchorElement>}
+          href={href}
+          className={combinedClassName}
+          onClick={handleClick}
+          aria-disabled={disabled || loading}
+        >
+          <span className="flex items-center justify-center gap-1">{children}</span>
+        </Link>
+      );
+    }
+
+    return (
+      <button
+        ref={ref}
+        disabled={disabled || loading}
+        className={combinedClassName}
+        {...props}
+      >
+        {children}
+      </button>
+    );
+  }
+);
+
+Button.displayName = 'Button';
+
+export default Button;

--- a/src/types/buttonType.ts
+++ b/src/types/buttonType.ts
@@ -1,0 +1,60 @@
+import { ButtonHTMLAttributes, ReactNode } from 'react';
+
+/**
+ * 버튼 변형 타입
+ * @property primary - 배경색이 있는 주요 버튼
+ * @property secondary - 테두리만 있는 보조 버튼
+ */
+export type ButtonVariant = 'primary' | 'secondary';
+
+/**
+ * 버튼 크기 타입
+ * @property sm - 작은 크기 (120px 최소 너비)
+ * @property md - 중간 크기 (160px 최소 너비)
+ * @property lg - 큰 크기 (전체 너비)
+ */
+export type ButtonSize = 'sm' | 'md' | 'lg';
+
+/**
+ * Button 컴포넌트 Props
+ */
+export interface ButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onClick'> {
+  /**
+   * 버튼 스타일 변형
+   * @default 'primary'
+   */
+  variant?: ButtonVariant;
+
+  /**
+   * 버튼 크기
+   * @default 'md'
+   */
+  size?: ButtonSize;
+
+  /**
+   * 로딩 상태 여부
+   * @default false
+   */
+  loading?: boolean;
+
+  /**
+   * 로딩 중 점 애니메이션 표시 여부
+   * @default true
+   */
+  showLoadingDots?: boolean;
+
+  /**
+   * 전체 너비 사용 여부
+   * @default false
+   */
+  fullWidth?: boolean;
+
+  /**
+   * 버튼 내용
+   */
+  children: ReactNode;
+
+  href?: string; // 링크(페이지 이동 등)
+
+  onClick?: React.MouseEventHandler<HTMLButtonElement | HTMLAnchorElement>;
+}


### PR DESCRIPTION
## 📌 PR 개요
- 관리가 편하도록 하기 위해서 버튼 타입 파일을 types에 따로 지정
- sm | md | lg 세 가지 사이즈로 버튼을 나눔.
- 파란색 버튼과, 하얀색 배경 기준으로 disabled 값으로 설정
- Link와 button을 상황에 따라 자동 렌더링
- 다양한 옵션을 props로 받을 수 있음
- 애니메이션 넣어서 로딩시 통통 튀는 거 넣으려다 일단 빼고 커밋함.

**href를 주면 자동으로 <a>, 즉 Next.js의 Link로 동작**
<Button href="/about">About 페이지로 이동</Button>

**버튼 온클릭 사용시** 
<Button onClick={() => alert('클릭됨!')}>클릭</Button>

**기타 className 등 추가 스타일**
<Button className="my-custom-class">추가 스타일</Button>

### **Props 예시** 
```
<Button` variant="primary" size="md" fullWidth loading>
  불러오는 중
</Button>
```

```
<Button variant="secondary" size="sm" disabled>
  보조(비활성화)
</Button>
```

```
<Button href="/profile" size="lg">
  프로필 이동
</Button>
```

## 🔍 관련 이슈

- Closes #56 
- Closes #55 

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [X] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- 주요 변경 내용을 리스트로 정리해주세요.

`ex`

- 로그인 API 연동 (`/api/login`) 추가
- 로그인 폼에서 이메일/비밀번호 유효성 검사 로직 추가
- 로그인 성공 시 JWT 토큰을 localStorage에 저장하도록 수정
- UI: 로그인 버튼 클릭 시 로딩 스피너 추가

## 📝 PR 제목 규칙

PR 제목은 커밋 컨벤션을 따라야 합니다.  
ex) feat: 롤링페이퍼 작성 기능 추가 (#15)

## ✅ 체크리스트

- [ ] 코드가 정상 동작함
- [ ] 빌드 및 실행 확인 완료
- [ ] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

- UI 변경이 있다면 캡처 이미지 첨부

## 🤝 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 맥락(설계 의도, 제약사항 등)
