### PR TITLE
feat: notification modal 구현(#76)

### DIFF
--- a/src/components/Header/Hedaer.tsx
+++ b/src/components/Header/Hedaer.tsx
@@ -22,7 +22,7 @@ export default function Header({ isLoggedIn = false }: HeaderProps) {
         </Link>
 
         {/* 오른쪽 */}
-        <div className="flex justify-end">
+        <div className="flex justify-end items-center">
           {isLoggedIn ? (
             <LoggedInMenu nickname={nickname} />
           ) : (

--- a/src/components/Header/LoggedInMenu.tsx
+++ b/src/components/Header/LoggedInMenu.tsx
@@ -1,21 +1,36 @@
+"use client";
+
+import { useState } from "react";
 import BellIcon from "@/assets/icon_bell.svg";
 import DefaultProfile from "@/assets/default profile.svg";
 import Link from "next/link";
+import NotificationPanel from "@/src/components/Notification/NotificationPanel";
+import { mockNotifications } from "@/src/components/Notification/mock";
 
 type LoggedInMenuProps = {
   nickname: string;
 };
 
 export default function LoggedInMenu({ nickname }: LoggedInMenuProps) {
+  const [open, setOpen] = useState(false);
+
   return (
-    <div className="flex items-center gap-2.5">
-      <Link
-        href="/notifications"
+    <div className="absolute flex items-center gap-2.5">
+      <button
+        type="button"
         aria-label="알림"
+        onClick={() => setOpen((prev) => !prev)}
         className="hover:opacity-70 transition"
       >
         <BellIcon />
-      </Link>
+      </button>
+      {open && (
+        <NotificationPanel
+          notifications={mockNotifications}
+          totalCount={mockNotifications.length}
+          onClose={() => setOpen(false)}
+        />
+      )}
       <Link
         href="/mypage"
         aria-label="마이페이지"

--- a/src/components/Notification/NotificationItem.tsx
+++ b/src/components/Notification/NotificationItem.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { NotificationUIItem } from "./types";
+
+interface Props {
+  item: NotificationUIItem;
+}
+
+export default function NotificationItem({ item }: Props) {
+  const isApprove = item.content.includes("승인");
+  const isReject = item.content.includes("거절");
+
+  const highlightWord = isApprove ? "승인" : isReject ? "거절" : null;
+
+  let before = item.content;
+  let after = "";
+
+  if (highlightWord) {
+    [before, after] = item.content.split(highlightWord);
+  }
+
+  return (
+    <div className={`px-4 py-3 ${isApprove ? "bg-blue-50" : "bg-white"}`}>
+      <div className="flex items-center justify-between">
+        <p className="text-sm font-bold">
+          {isApprove ? "예약 승인" : "예약 거절"}
+        </p>
+        <span className="text-xs text-gray-400">
+          {formatRelativeTime(item.createdAt)}
+        </span>
+      </div>
+
+      <p className="mt-1 text-sm text-gray-900">{item.activityTitle}</p>
+      <p className="text-xs text-gray-500">{item.scheduleText}</p>
+
+      <p className="mt-1 text-sm text-gray-700">
+        {before}
+        {highlightWord && (
+          <span
+            className={`font-medium ${
+              isApprove ? "text-blue-600" : "text-red-600"
+            }`}
+          >
+            {highlightWord}
+          </span>
+        )}
+        {after}
+      </p>
+    </div>
+  );
+}
+
+function formatRelativeTime(dateString: string) {
+  const diff = (Date.now() - new Date(dateString).getTime()) / 1000;
+
+  if (diff < 60) return "방금 전";
+  if (diff < 3600) return `${Math.floor(diff / 60)}분 전`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}시간 전`;
+  return `${Math.floor(diff / 86400)}일 전`;
+}

--- a/src/components/Notification/NotificationPanel.tsx
+++ b/src/components/Notification/NotificationPanel.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import DeleteIcon from "@/assets/icon_delete.svg";
+import NotificationItem from "./NotificationItem";
+import { NotificationUIItem } from "./types";
+
+interface Props {
+  notifications: NotificationUIItem[];
+  totalCount: number;
+  onClose: () => void;
+}
+
+export default function NotificationPanel({
+  notifications,
+  totalCount,
+  onClose,
+}: Props) {
+  return (
+    <div
+      className="
+        absolute right-0 top-[40px] z-50
+        w-[231px]
+        rounded-xl bg-white
+        shadow-[0_2px_8px_rgba(156,180,202,0.2)]
+      "
+    >
+      <div className="flex items-center justify-between px-4 py-3">
+        <p className="text-sm font-bold">알림 {totalCount}개</p>
+        <button onClick={onClose} aria-label="닫기">
+          <DeleteIcon />
+        </button>
+      </div>
+
+      <div className="flex flex-col">
+        {notifications.length === 0 ? (
+          <p className="py-8 text-center text-sm text-gray-400">
+            새로운 알림이 없습니다.
+          </p>
+        ) : (
+          notifications.map((item) => (
+            <NotificationItem key={item.id} item={item} />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Notification/mock.ts
+++ b/src/components/Notification/mock.ts
@@ -1,0 +1,18 @@
+import { NotificationUIItem } from "@/src/components/Notification/types";
+
+export const mockNotifications: NotificationUIItem[] = [
+  {
+    id: 1,
+    content: "예약이 승인되었습니다.",
+    createdAt: new Date(Date.now() - 60 * 1000).toISOString(),
+    activityTitle: "함께 배운 즐거운 스트릿 댄스",
+    scheduleText: "(2023-01-14 15:00~18:00)",
+  },
+  {
+    id: 2,
+    content: "예약이 거절되었습니다.",
+    createdAt: new Date(Date.now() - 7 * 60 * 1000).toISOString(),
+    activityTitle: "함께 배운 즐거운 스트릿 댄스",
+    scheduleText: "(2023-01-14 15:00~18:00)",
+  },
+];

--- a/src/components/Notification/types.ts
+++ b/src/components/Notification/types.ts
@@ -1,0 +1,8 @@
+export interface NotificationUIItem {
+  id: number;
+  content: string;
+  createdAt: string;
+
+  activityTitle: string;
+  scheduleText: string;
+}


### PR DESCRIPTION
## 📌 PR 개요

- notification modal 구현

## 🔍 관련 이슈

- Closes #76 

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [x] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [x] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- Header 우측 영역 요소 가운데 정렬 리팩토링
- Notification Modal 구현
- 헤더 영역의 알림 아이콘 클릭 시 Notification Modal 출력
- 알림 메시지 내 승인/거절 텍스트 색상 적용
- notification Modal 동작 확인을 위한  Mock 데이터 추가
- 알림 항목에 예약 상태(승인/거절), 알림 발생 시점, 체험 제목, 체험 일정, 알림 메시지 출력



## 📝 PR 제목 규칙

feat: notification modal 구현(#76)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)


<img width="1919" height="905" alt="스크린샷 2025-12-26 200226" src="https://github.com/user-attachments/assets/5ee0443c-e687-4254-80d8-41a0f42be829" />

## 🤝 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 맥락(설계 의도, 제약사항 등)
