### PR TITLE
fix: 유저메뉴 드롭다운 수정 (#101)

### DIFF
--- a/src/components/Dropdown/UserMenuDropDown.tsx
+++ b/src/components/Dropdown/UserMenuDropDown.tsx
@@ -16,7 +16,7 @@ export default function UserMenuDropDownProps({
     const items: DropdownItem[] = [
         {
             type: 'link',
-            label: '마이 페이지',
+            label: '마이페이지',
             href: '/mypage',
         },
         {
@@ -30,11 +30,11 @@ export default function UserMenuDropDownProps({
         <Dropdown
             label={userName}
             items={items}
-            align="end"
+            align="center"
             showArrow={false}
             fullWidth={false}
             className={`[&>button>span]:hover:text-gray-700 ${className}`}
-            menuClassName="min-w-[0px]"
+            menuClassName="min-w-[100px] mt-1"
         />
     );
 }

--- a/src/components/Header/LoggedInMenu.tsx
+++ b/src/components/Header/LoggedInMenu.tsx
@@ -50,7 +50,6 @@ export default function LoggedInMenu({
       <UserMenuDropDown
         userName={nickname}
         onLogout={onLogout}
-        className="absolute  min-w-[120px]"
       />
     </div>
   );


### PR DESCRIPTION
## 📌 PR 개요

헤더부분 유저메뉴 드롭다운 ui 개선

## 🔍 관련 이슈

- Closes #101 

## 🔧 변경 유형

- [ ] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [x] 🎨 style (코드 스타일 변경)
- [x] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- 유저메뉴 드롭다운 컴포넌트 ui 개선

## 📝 PR 제목 규칙

fix: 유저메뉴 드롭다운 수정 (#101)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

<img width="170" height="152" alt="image" src="https://github.com/user-attachments/assets/377fa848-cc42-4fb3-93f2-3fd6630dff99" />

## 🤝 기타 참고 사항

- 프로필 이미지가 가려지지 않도록 mt-1을 줘서 공백을 줬는데, 이로 인해서 이름과 드롭다운 사이의 공백을 눌러도 드롭다운 조작이 안되는데, ui적으론 되긴 했는데 드롭다운 펼치고 끄는건 이게 맞는 지 잘 모르겠습니다
- 패딩을 줘서 해결하기엔 헤더 ui가 깨지기 때문에 사실 이대로 진행해도 문제는 없습니다.