### PR TITLE
feat: popover 컴포넌트 구현(#129)

### DIFF
--- a/src/app/dev/donghyeon/page.tsx
+++ b/src/app/dev/donghyeon/page.tsx
@@ -1,25 +1,117 @@
 "use client";
 
-import { useState } from "react";
-import CompleteModal from "@/src/components/Modal/CompleteModal";
+import { useRef, useState } from "react";
+import { format } from "date-fns";
+
+import ReservationPopover from "@/src/components/Popover/Popover";
+import { CalendarDayCell } from "@/src/components/Calendar/CalendarDayCell";
 
 export default function DonghyeonPage() {
-  const [open, setOpen] = useState(false);
+  const anchorRef = useRef<HTMLElement | null>(null);
+
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+
+  /* 날짜 클릭 */
+  const handleDayClick = (e: React.MouseEvent<HTMLDivElement>, date: Date) => {
+    anchorRef.current = e.currentTarget;
+    setSelectedDate(date);
+    setPopoverOpen(true);
+  };
 
   return (
-    <div className="p-10">
-      <button
-        onClick={() => setOpen(true)}
-        className="rounded-lg bg-blue-500 px-4 py-2 text-sm font-medium text-white"
-      >
-        CompleteModal 열기
-      </button>
+    <div className="p-10 space-y-10">
+      {/* ===============================
+          Calendar 영역
+      =============================== */}
+      <div className="grid grid-cols-5 gap-4 h-[124px]">
+        {/* 1일 */}
+        <div
+          onClick={(e) => handleDayClick(e, new Date(2025, 12, 1))}
+          className="cursor-pointer"
+        >
+          <CalendarDayCell
+            day={1}
+            summary={{
+              reserved: 0,
+              approved: 0,
+              completed: 0,
+            }}
+          />
+        </div>
 
-      <CompleteModal
-        isOpen={open}
-        onClose={() => setOpen(false)}
-        message="완료되었습니다"
-      />
+        {/* 2일 - 예약 있음 */}
+        <div
+          onClick={(e) => handleDayClick(e, new Date(2025, 12, 2))}
+          className="cursor-pointer"
+        >
+          <CalendarDayCell
+            day={2}
+            summary={{
+              reserved: 2,
+              approved: 0,
+              completed: 0,
+            }}
+          />
+        </div>
+
+        {/* 3일 - 예약 + 승인 */}
+        <div
+          onClick={(e) => handleDayClick(e, new Date(2025, 12, 3))}
+          className="cursor-pointer"
+        >
+          <CalendarDayCell
+            day={3}
+            summary={{
+              reserved: 1,
+              approved: 3,
+              completed: 0,
+            }}
+          />
+        </div>
+
+        {/* 4일 - 예약 + 승인 + 완료 */}
+        <div
+          onClick={(e) => handleDayClick(e, new Date(2025, 12, 4))}
+          className="cursor-pointer"
+        >
+          <CalendarDayCell
+            day={4}
+            summary={{
+              reserved: 1,
+              approved: 1,
+              completed: 1,
+            }}
+          />
+        </div>
+
+        {/* 5일 - 완료만 */}
+        <div
+          onClick={(e) => handleDayClick(e, new Date(2025, 12, 5))}
+          className="cursor-pointer"
+        >
+          <CalendarDayCell
+            day={5}
+            summary={{
+              reserved: 0,
+              approved: 0,
+              completed: 4,
+            }}
+          />
+        </div>
+      </div>
+
+      {/* ===============================
+          Popover
+      =============================== */}
+      {selectedDate && (
+        <ReservationPopover
+          isOpen={popoverOpen}
+          onClose={() => setPopoverOpen(false)}
+          dateLabel={format(selectedDate, "yyyy년 M월 d일")}
+          anchorRef={anchorRef}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { RefObject, useEffect, useRef, useState } from "react";
+import StatusBadge from "@/src/components/StatusBadge/StatusBadge";
+import DeleteIcon from "@/src/assets/icon_delete.svg";
+
+type TabKey = "requested" | "approved" | "declined";
+
+interface Reservation {
+  id: number;
+  name: string;
+  people: number;
+  time: string;
+  status?: "pending" | "declined";
+}
+
+interface ReservationPopoverProps {
+  isOpen: boolean;
+  onClose: () => void;
+  dateLabel: string;
+  anchorRef: RefObject<HTMLElement | null>;
+}
+
+const INITIAL_RESERVATIONS: Reservation[] = [
+  {
+    id: 1,
+    name: "정만철",
+    people: 10,
+    time: "14:00 - 15:00",
+  },
+  {
+    id: 2,
+    name: "정만철",
+    people: 12,
+    time: "14:00 - 15:00",
+  },
+];
+
+const TAB_LABEL: Record<TabKey, string> = {
+  requested: "신청",
+  approved: "승인",
+  declined: "거절",
+};
+
+export default function ReservationPopover({
+  isOpen,
+  onClose,
+  dateLabel,
+  anchorRef,
+}: ReservationPopoverProps) {
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const [style, setStyle] = useState<React.CSSProperties>({});
+
+  const [activeTab, setActiveTab] = useState<TabKey>("requested");
+  const [reservations, setReservations] =
+    useState<Reservation[]>(INITIAL_RESERVATIONS);
+
+  const timeOptions = Array.from(new Set(reservations.map((r) => r.time)));
+
+  const [selectedTime, setSelectedTime] = useState(timeOptions[0] ?? "");
+
+  useEffect(() => {
+    if (!isOpen || !anchorRef.current) return;
+
+    const rect = anchorRef.current.getBoundingClientRect();
+    setStyle({
+      position: "fixed",
+      top: rect.top,
+      left: rect.right + 8,
+      zIndex: 50,
+    });
+  }, [isOpen, anchorRef]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        popoverRef.current &&
+        !popoverRef.current.contains(e.target as Node) &&
+        !anchorRef.current?.contains(e.target as Node)
+      ) {
+        onClose();
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isOpen, onClose, anchorRef]);
+
+  if (!isOpen) return null;
+
+  const approve = (id: number) => {
+    setReservations((prev) =>
+      prev.map((r) => (r.id === id ? { ...r, status: "pending" } : r))
+    );
+    setActiveTab("approved");
+  };
+
+  const decline = (id: number) => {
+    setReservations((prev) =>
+      prev.map((r) => (r.id === id ? { ...r, status: "declined" } : r))
+    );
+    setActiveTab("declined");
+  };
+
+  const filtered = reservations.filter((r) => {
+    if (r.time !== selectedTime) return false;
+
+    if (activeTab === "requested") return r.status === undefined;
+    if (activeTab === "approved") return r.status === "pending";
+    if (activeTab === "declined") return r.status === "declined";
+  });
+
+  return (
+    <aside
+      ref={popoverRef}
+      style={style}
+      className="w-85 rounded-xl bg-white shadow-lg"
+    >
+      <div className="flex flex-col p-6 gap-6">
+        {/* Header */}
+        <header className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold">{dateLabel}</h2>
+          <button
+            aria-label="닫기"
+            onClick={onClose}
+            className="flex items-center justify-center"
+          >
+            <DeleteIcon />
+          </button>
+        </header>
+
+        {/* Tabs */}
+        <div className="flex gap-6 border-b border-gray-100 text-sm">
+          {(Object.keys(TAB_LABEL) as TabKey[]).map((tab) => (
+            <button
+              key={tab}
+              onClick={() => setActiveTab(tab)}
+              className={`pb-2 ${
+                activeTab === tab
+                  ? "border-b-2 border-primary-500 text-primary-500 font-semibold"
+                  : "text-gray-400"
+              }`}
+            >
+              {TAB_LABEL[tab]}
+            </button>
+          ))}
+        </div>
+
+        {/* 예약 시간 */}
+        <section>
+          <h3 className="text-m font-bold mb-2">예약 시간</h3>
+          <select
+            value={selectedTime}
+            onChange={(e) => setSelectedTime(e.target.value)}
+            className="w-full rounded-lg border border-gray-100 px-3 py-2 text-sm"
+          >
+            {timeOptions.map((time) => (
+              <option key={time} value={time}>
+                {time}
+              </option>
+            ))}
+          </select>
+        </section>
+
+        {/* 예약 내역 */}
+        <section className="flex flex-col gap-3">
+          <h3 className="text-m font-bold mb-2">예약 내역</h3>
+          {filtered.length === 0 && (
+            <p className="text-sm text-gray-400">예약 내역이 없습니다.</p>
+          )}
+
+          {filtered.map((r) => (
+            <div
+              key={r.id}
+              className="flex justify-between items-center border border-gray-100 rounded-xl p-3"
+            >
+              <div>
+                <p className="text-sm">
+                  <span className="text-gray-500 font-bold">닉네임 </span>
+                  <span className="text-black">{r.name}</span>
+                </p>
+                <p className="text-sm">
+                  <span className="text-gray-500 font-bold">인원 </span>
+                  <span className="text-black">{r.people}명</span>
+                </p>
+              </div>
+
+              {activeTab === "requested" ? (
+                <div className="flex flex-col text-sm gap-1">
+                  <button
+                    onClick={() => approve(r.id)}
+                    className="px-3 py-1 rounded-full bg-white border border-gray-50 text-gray-600 text-xs font-semibold"
+                  >
+                    승인하기
+                  </button>
+
+                  <button
+                    onClick={() => decline(r.id)}
+                    className=" px-3 py-1 rounded-full bg-gray-50 text-gray-600 text-xs font-semibold"
+                  >
+                    거절하기
+                  </button>
+                </div>
+              ) : (
+                <StatusBadge status={r.status!} />
+              )}
+            </div>
+          ))}
+        </section>
+      </div>
+    </aside>
+  );
+}


### PR DESCRIPTION
## 📌 PR 개요

popover 컴포넌트 구현

## 🔍 관련 이슈

- Closes #129 


## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [x] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [x] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- 캘린더 날짜 클릭 시 표시되는 예약 관리 Popover 컴포넌트 구현
- 특정 날짜를 기준으로 우측에 배치되도록 Popover 포지셔닝
- 신청 / 승인 / 거절 탭 분리 및 상태별 예약 목록 필터링
- 예약 시간 별 필터링 기능 추가 -> Dropdown 수정시 Dropdown 컴포넌트 적용 예정
- 신청 상태에서는 승인하기 / 거절하기 액션 구현
- 승인 / 거절 상태에서는 StatusBadge 컴포넌트로 상태 표시
- 외부 클릭 시 Popover 닫힘 처리(x버튼도 닫힘 처리 적용)


## 📝 PR 제목 규칙

feat: popover 컴포넌트 구현(#129)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)


<img width="1919" height="911" alt="스크린샷 2025-12-31 005109" src="https://github.com/user-attachments/assets/7db9b90a-468e-4877-a028-73c0ef1a9c9e" />
<img width="1918" height="915" alt="스크린샷 2025-12-31 005118" src="https://github.com/user-attachments/assets/58f0d664-c19a-479a-b142-20f56e405c99" />
<img width="1918" height="914" alt="스크린샷 2025-12-31 010026" src="https://github.com/user-attachments/assets/0548e264-127c-4b0f-b87d-a6f301c8a1e4" />


## 🤝 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 맥락(설계 의도, 제약사항 등)
