### PR TITLE
feat: login api 로직 구현(#136)

### DIFF
--- a/src/app/(public)/login/page.tsx
+++ b/src/app/(public)/login/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import Link from "next/link";
 import LogoIcon from "@/src/assets/LoginLogo.svg";
 import KakaoIcon from "@/src/assets/icon_kakao.svg";
@@ -8,9 +9,13 @@ import Button from "@/src/components/button/button";
 import Input from "@/src/components/Input/Input";
 import CompleteModal from "@/src/components/Modal/CompleteModal";
 import { useLoginForm } from "@/src/features/public/hooks/useLoginForm";
+import { useLoginSubmit } from "@/src/features/public/hooks/useLoginSubmit";
 
 export default function LoginPage() {
+  const router = useRouter();
+  const loginForm = useLoginForm();
   const [showPassword, setShowPassword] = useState(false);
+  const { submitLogin } = useLoginSubmit();
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const {
@@ -18,21 +23,26 @@ export default function LoginPage() {
     emailError,
     handleEmailChange,
     handleEmailBlur,
-
     password,
     passwordError,
     handlePasswordChange,
     handlePasswordBlur,
-
     isFormValid,
-  } = useLoginForm();
+  } = loginForm;
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
     if (!isFormValid) return;
 
-    setIsModalOpen(true); // 임시 UI 확인용 -> API 연동 로직 구현 예정
+    const ok = await submitLogin(email, password);
+
+    if (!ok) {
+      setIsModalOpen(true);
+      return;
+    }
+
+    router.push("/");
   };
 
   return (

--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -32,7 +32,7 @@ export async function POST(req: Request) {
     // refreshToken → httpOnly 쿠키
     response.cookies.set("refreshToken", data.refreshToken, {
       httpOnly: true,
-      path: "/",
+      path: "/api",
     });
 
     return response;

--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+  try {
+    const { email, password } = await req.json();
+
+    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/login`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ email, password }),
+    });
+
+    const data = await res.json();
+
+    if (!res.ok) {
+      return NextResponse.json(
+        { message: data.message ?? "로그인 실패" },
+        { status: res.status }
+      );
+    }
+
+    const response = NextResponse.json({ user: data.user }, { status: 201 });
+
+    // accessToken → httpOnly 쿠키
+    response.cookies.set("accessToken", data.accessToken, {
+      httpOnly: true,
+      path: "/",
+    });
+
+    // refreshToken → httpOnly 쿠키
+    response.cookies.set("refreshToken", data.refreshToken, {
+      httpOnly: true,
+      path: "/",
+    });
+
+    return response;
+  } catch (err) {
+    console.error("LOGIN ROUTE ERROR:", err);
+    return NextResponse.json({ message: "서버 오류" }, { status: 500 });
+  }
+}

--- a/src/app/api/refresh/route.ts
+++ b/src/app/api/refresh/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+export async function POST() {
+  const cookieStore = await cookies();
+  const refreshToken = cookieStore.get("refreshToken")?.value;
+
+  if (!refreshToken) {
+    return NextResponse.json(
+      { message: "Refresh token 없음" },
+      { status: 401 }
+    );
+  }
+
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/tokens`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ refreshToken }),
+  });
+
+  if (!res.ok) {
+    return NextResponse.json({ message: "재발급 실패" }, { status: 401 });
+  }
+
+  const data = await res.json();
+
+  const response = NextResponse.json({ ok: true });
+
+  response.cookies.set("accessToken", data.accessToken, {
+    httpOnly: true,
+    path: "/",
+  });
+
+  return response;
+}

--- a/src/app/api/token/route.ts
+++ b/src/app/api/token/route.ts
@@ -1,0 +1,17 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+/**
+ * 클라이언트에서 토큰이 필요할 때 호출하는 API
+ * httpOnly 쿠키에서 accessToken을 읽어 반환
+ */
+export async function GET() {
+  const cookieStore = await cookies();
+  const token = cookieStore.get("accessToken")?.value;
+
+  if (!token) {
+    return NextResponse.json({ error: "인증 실패" }, { status: 401 });
+  }
+
+  return NextResponse.json({ token });
+}

--- a/src/features/public/hooks/useLoginSubmit.ts
+++ b/src/features/public/hooks/useLoginSubmit.ts
@@ -1,0 +1,25 @@
+import { useState } from "react";
+import { authService } from "../services/authService";
+
+export function useLoginSubmit() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [loginError, setLoginError] = useState<string | null>(null);
+
+  const submitLogin = async (email: string, password: string) => {
+    setIsLoading(true);
+    setLoginError(null);
+
+    try {
+      await authService.login(email, password);
+      return true;
+    } catch (err) {
+      console.error(err);
+      setLoginError("로그인에 실패했습니다.");
+      return false;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { submitLogin, isLoading, loginError };
+}

--- a/src/features/public/services/authService.ts
+++ b/src/features/public/services/authService.ts
@@ -1,0 +1,18 @@
+export const authService = {
+  login: async (email: string, password: string) => {
+    const res = await fetch("/api/login", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ email, password }),
+    });
+
+    // 실패하면 에러 throw → LoginPage catch로 이동
+    if (!res.ok) {
+      throw new Error("LOGIN_FAILED");
+    }
+
+    return;
+  },
+};

--- a/src/features/public/services/authService.ts
+++ b/src/features/public/services/authService.ts
@@ -5,6 +5,7 @@ export const authService = {
       headers: {
         "Content-Type": "application/json",
       },
+      credentials: "include",
       body: JSON.stringify({ email, password }),
     });
 

--- a/src/lib/hooks/useToken.ts
+++ b/src/lib/hooks/useToken.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function useToken() {
+  const [token, setToken] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch("/api/token", {
+      credentials: "include",
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error("unauthorized");
+        return res.json();
+      })
+      .then((data) => setToken(data.token))
+      .catch(() => setToken(null))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return { token, loading };
+}


### PR DESCRIPTION
## 📌 PR 개요

- 로그인 api  연동 및 로직 구현

## 🔍 관련 이슈

- Closes #136

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [x] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

로그인 페이지 구현 (LoginPage)
- useLoginSubmit 훅을 사용해 로그인 요청 트리거
- 로그인 성공 시 메인 페이지(/)로 이동

로그인 API Route 추가 (app/api/login/route.ts)
- 로그인 성공 시: accessToken, refreshToken을 httpOnly 쿠키로 설정, 클라이언트에는 토큰을 직접 노출하지 않음
- 로그인 실패 시: 외부 API의 에러 메시지 및 상태 코드를 그대로 반환

로그인 요청 훅 (useLoginSubmit)
- 로그인 요청 시 로딩 상태(isLoading) 관리
- 로그인 실패 시 공통 에러 처리

인증 서비스 레이어 (authService)
- /api/login API 호출을 담당
- httpOnly 쿠키 기반 인증 구조에 따라 클라이언트에서는 토큰을 직접 다루지 않고 Next API Route에서 쿠키로 설정

클라이언트 토큰 필요 API(/api/token/route.ts)
- 서버에서 httpOnly 쿠키의 accessToken을 읽어서 반환
- 클라이언트는 이 API를 통해 토큰 사용

토큰 재발급 API(/api/refresh/route.ts)
- 쿠키의 refreshToken을 이용하여 /auth/tokens 호출
- 재발급 된 accessToken을 사용하여 다시 쿠키 저장

클라이언트 토큰 사용 훅(useToken)
- /api/token 호출을 통해 토큰 상태 관리
- 클라이언트 컴포넌트에서 토큰 필요 여부를 판단

## 📝 PR 제목 규칙

feat: login api 로직 구현(#136)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)
<img width="652" height="119" alt="스크린샷 2025-12-31 165528" src="https://github.com/user-attachments/assets/94e30753-696e-4441-bf2f-4be9b82ce932" />

<img width="620" height="250" alt="스크린샷 2025-12-31 165536" src="https://github.com/user-attachments/assets/7cb5a4dc-56b6-4baf-9702-8fde3ab0858c" />

<img width="739" height="131" alt="스크린샷 2025-12-31 165510" src="https://github.com/user-attachments/assets/9605678f-9895-44d8-a83d-0151f00162bf" />

## 🤝 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 맥락(설계 의도, 제약사항 등)
