### PR TITLE
feat: signup 페이지 UI 및 폼로직 구현(#141)

### DIFF
--- a/src/app/(public)/signup/page.tsx
+++ b/src/app/(public)/signup/page.tsx
@@ -1,3 +1,119 @@
-export default function Page() {
-  return <div />;
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import LogoIcon from "@/src/assets/LoginLogo.svg";
+import KakaoIcon from "@/src/assets/icon_kakao.svg";
+import Button from "@/src/components/button/button";
+import Input from "@/src/components/Input/Input";
+import { useSignupForm } from "@/src/features/public/hooks/useSignupForm";
+
+export default function SignupPage() {
+  const signupForm = useSignupForm();
+  const [showPassword, setShowPassword] = useState(false);
+
+  const {
+    email,
+    nickname,
+    password,
+    passwordConfirm,
+
+    emailError,
+    nicknameError,
+    passwordError,
+    passwordConfirmError,
+
+    handleEmailChange,
+    handleEmailBlur,
+    handleNicknameChange,
+    handleNicknameBlur,
+    handlePasswordChange,
+    handlePasswordBlur,
+    handlePasswordConfirmChange,
+    handlePasswordConfirmBlur,
+
+    isFormValid,
+  } = signupForm;
+
+  return (
+    <div className="min-h-screen bg-white">
+      <div className="mx-auto flex min-h-screen max-w-105 flex-col items-center justify-center px-4">
+        <Link href="/" className="cursor-pointer select-none mb-6">
+          <LogoIcon />
+        </Link>
+
+        <form className="w-full flex flex-col pt-5 gap-3">
+          <div className="flex flex-col pb-7.5">
+            <Input
+              label="이메일"
+              placeholder="이메일을 입력해 주세요"
+              value={email}
+              onChange={handleEmailChange}
+              onBlur={handleEmailBlur}
+              error={emailError || undefined}
+            />
+
+            <Input
+              label="닉네임"
+              placeholder="닉네임을 입력해 주세요"
+              value={nickname}
+              onChange={handleNicknameChange}
+              onBlur={handleNicknameBlur}
+              error={nicknameError || undefined}
+            />
+
+            <Input
+              label="비밀번호"
+              type={showPassword ? "text" : "password"}
+              placeholder="8자 이상 입력해 주세요"
+              value={password}
+              onChange={handlePasswordChange}
+              onBlur={handlePasswordBlur}
+              error={passwordError || undefined}
+              onTogglePassword={() => setShowPassword((prev) => !prev)}
+            />
+
+            <Input
+              label="비밀번호 확인"
+              type={showPassword ? "text" : "password"}
+              placeholder="비밀번호를 한 번 더 입력해 주세요"
+              value={passwordConfirm}
+              onChange={handlePasswordConfirmChange}
+              onBlur={handlePasswordConfirmBlur}
+              error={passwordConfirmError || undefined}
+            />
+          </div>
+
+          <Button
+            variant="primary"
+            fullWidth
+            disabled={!isFormValid}
+            className="mt-4"
+          >
+            회원가입하기
+          </Button>
+
+          <div className="flex w-full items-center gap-4 my-4">
+            <div className="h-px flex-1 bg-gray-200" />
+            <span className="text-sm text-gray-200">
+              SNS 계정으로 회원가입하기
+            </span>
+            <div className="h-px flex-1 bg-gray-200" />
+          </div>
+
+          <Button variant="secondary" fullWidth href="/oauth/signup/kakao">
+            <KakaoIcon />
+            카카오 회원가입
+          </Button>
+
+          <p className="mt-6 text-center text-sm text-gray-400">
+            이미 계정이 있으신가요?{" "}
+            <Link href="/login" className="hover:underline">
+              로그인하기
+            </Link>
+          </p>
+        </form>
+      </div>
+    </div>
+  );
 }

--- a/src/app/(public)/signup/page.tsx
+++ b/src/app/(public)/signup/page.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import LogoIcon from "@/src/assets/LoginLogo.svg";
 import KakaoIcon from "@/src/assets/icon_kakao.svg";
-import Button from "@/src/components/button/button";
+import Button from "@/src/components/Button/Button";
 import Input from "@/src/components/Input/Input";
 import { useSignupForm } from "@/src/features/public/hooks/useSignupForm";
 

--- a/src/features/public/hooks/useSignupForm.ts
+++ b/src/features/public/hooks/useSignupForm.ts
@@ -1,0 +1,112 @@
+import { useState } from "react";
+import {
+  isValidEmail,
+  isValidPassword,
+} from "@/src/features/public/utils/validators";
+
+export function useSignupForm() {
+  const [email, setEmail] = useState("");
+  const [nickname, setNickname] = useState("");
+  const [password, setPassword] = useState("");
+  const [passwordConfirm, setPasswordConfirm] = useState("");
+
+  const [emailError, setEmailError] = useState<string | null>(null);
+  const [nicknameError, setNicknameError] = useState<string | null>(null);
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+  const [passwordConfirmError, setPasswordConfirmError] = useState<
+    string | null
+  >(null);
+
+  // ===== validation (메시지 책임은 훅) =====
+  const validateEmail = (value: string) => {
+    if (!value) return "이메일을 입력해주세요.";
+    if (!isValidEmail(value)) return "올바른 이메일 형식이 아닙니다.";
+    return null;
+  };
+
+  const validateNickname = (value: string) => {
+    if (!value) return "닉네임을 입력해주세요.";
+    if (value.length < 2) return "닉네임은 2자 이상이어야 합니다.";
+    return null;
+  };
+
+  const validatePassword = (value: string) => {
+    if (!value) return "비밀번호를 입력해주세요.";
+    if (!isValidPassword(value)) return "비밀번호는 8자 이상이어야 합니다.";
+    return null;
+  };
+
+  const validatePasswordConfirm = (value: string) => {
+    if (!value) return "비밀번호 확인을 입력해주세요.";
+    if (value !== password) return "비밀번호가 일치하지 않습니다.";
+    return null;
+  };
+
+  // ===== handlers =====
+  const handleEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setEmail(e.target.value);
+    setEmailError(null);
+  };
+
+  const handleEmailBlur = () => {
+    setEmailError(validateEmail(email));
+  };
+
+  const handleNicknameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setNickname(e.target.value);
+    setNicknameError(null);
+  };
+
+  const handleNicknameBlur = () => {
+    setNicknameError(validateNickname(nickname));
+  };
+
+  const handlePasswordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setPassword(e.target.value);
+    setPasswordError(null);
+  };
+
+  const handlePasswordBlur = () => {
+    setPasswordError(validatePassword(password));
+  };
+
+  const handlePasswordConfirmChange = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setPasswordConfirm(e.target.value);
+    setPasswordConfirmError(null);
+  };
+
+  const handlePasswordConfirmBlur = () => {
+    setPasswordConfirmError(validatePasswordConfirm(passwordConfirm));
+  };
+
+  const isFormValid =
+    !validateEmail(email) &&
+    !validateNickname(nickname) &&
+    !validatePassword(password) &&
+    !validatePasswordConfirm(passwordConfirm);
+
+  return {
+    email,
+    nickname,
+    password,
+    passwordConfirm,
+
+    emailError,
+    nicknameError,
+    passwordError,
+    passwordConfirmError,
+
+    handleEmailChange,
+    handleEmailBlur,
+    handleNicknameChange,
+    handleNicknameBlur,
+    handlePasswordChange,
+    handlePasswordBlur,
+    handlePasswordConfirmChange,
+    handlePasswordConfirmBlur,
+
+    isFormValid,
+  };
+}


### PR DESCRIPTION
## 📌 PR 개요

- signup 페이지 UI 및 폼로직 구현

## 🔍 관련 이슈

- Closes #141 

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [x] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- useSignupForm 커스텀 훅을 사용하여 signup 페이지의 상태 관리 및 유효성 로직 분리
- 이메일 / 닉네임 / 비밀번호 / 비밀번호 확인 가각에 대한 onchange / onblur 책임 분리
- 이메일과 비밀번호 검증은 validator 유틸에서 isValidEmail, isValidPassword 재사용


## 📝 PR 제목 규칙

feat: signup 페이지 UI 및 폼로직 구현(#141)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

<img width="1919" height="910" alt="스크린샷 2026-01-01 132712" src="https://github.com/user-attachments/assets/38faf699-f015-429e-9137-a50bbd4e57ad" />
<img width="1919" height="907" alt="스크린샷 2026-01-01 132541" src="https://github.com/user-attachments/assets/730efb3d-7795-41c2-bed8-0b6938085b90" />
<img width="1919" height="906" alt="스크린샷 2026-01-01 133833" src="https://github.com/user-attachments/assets/081dc89b-2234-4fb4-a0be-ade63dd59bd0" />
<img width="1917" height="905" alt="스크린샷 2026-01-01 132610" src="https://github.com/user-attachments/assets/1d1aa696-be74-4885-9d33-ef452f843dda" />

## 🤝 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 맥락(설계 의도, 제약사항 등)
