### PR TITLE
feat: 회원가입 api 로직 구현(#142)

### DIFF
--- a/src/app/(public)/signup/page.tsx
+++ b/src/app/(public)/signup/page.tsx
@@ -1,16 +1,22 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import Link from "next/link";
 import LogoIcon from "@/src/assets/LoginLogo.svg";
 import KakaoIcon from "@/src/assets/icon_kakao.svg";
 import Button from "@/src/components/Button/Button";
 import Input from "@/src/components/Input/Input";
+import CompleteModal from "@/src/components/Modal/CompleteModal";
 import { useSignupForm } from "@/src/features/public/hooks/useSignupForm";
+import { useSignupSubmit } from "@/src/features/public/hooks/useSignupSubmit";
 
 export default function SignupPage() {
+  const router = useRouter();
   const signupForm = useSignupForm();
+  const { submitSignup, isLoading, signupError } = useSignupSubmit();
   const [showPassword, setShowPassword] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   const {
     email,
@@ -35,6 +41,25 @@ export default function SignupPage() {
     isFormValid,
   } = signupForm;
 
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    if (!isFormValid || isLoading) return;
+
+    const ok = await submitSignup({
+      email,
+      password,
+      nickname,
+    });
+
+    if (ok) {
+      setIsModalOpen(true);
+      return;
+    }
+
+    setIsModalOpen(true);
+  };
+
   return (
     <div className="min-h-screen bg-white">
       <div className="mx-auto flex min-h-screen max-w-105 flex-col items-center justify-center px-4">
@@ -42,7 +67,10 @@ export default function SignupPage() {
           <LogoIcon />
         </Link>
 
-        <form className="w-full flex flex-col pt-5 gap-3">
+        <form
+          onSubmit={handleSubmit}
+          className="w-full flex flex-col pt-5 gap-3"
+        >
           <div className="flex flex-col pb-7.5">
             <Input
               label="이메일"
@@ -114,6 +142,24 @@ export default function SignupPage() {
           </p>
         </form>
       </div>
+      {isModalOpen && !signupError && (
+        <CompleteModal
+          isOpen
+          message="가입이 완료되었습니다."
+          onClose={() => {
+            setIsModalOpen(false);
+            router.push("/login");
+          }}
+        />
+      )}
+
+      {isModalOpen && signupError && (
+        <CompleteModal
+          isOpen
+          message={signupError}
+          onClose={() => setIsModalOpen(false)}
+        />
+      )}
     </div>
   );
 }

--- a/src/app/api/signup/route.ts
+++ b/src/app/api/signup/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+
+    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/users`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+
+    const data = await res.json();
+
+    if (!res.ok) {
+      return NextResponse.json(
+        { message: data.message ?? "회원가입 실패" },
+        { status: res.status }
+      );
+    }
+
+    return NextResponse.json({ ok: true }, { status: 201 });
+  } catch (err) {
+    console.error("SIGNUP ROUTE ERROR:", err);
+    return NextResponse.json({ message: "서버 오류" }, { status: 500 });
+  }
+}

--- a/src/features/public/hooks/useSignupSubmit.ts
+++ b/src/features/public/hooks/useSignupSubmit.ts
@@ -1,0 +1,41 @@
+import { useState } from "react";
+import { authService } from "../services/authService";
+
+type SignupData = {
+  email: string;
+  password: string;
+  nickname: string;
+};
+
+export function useSignupSubmit() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [signupError, setSignupError] = useState<string | null>(null);
+
+  const submitSignup = async (signupData: SignupData) => {
+    setIsLoading(true);
+    setSignupError(null);
+
+    try {
+      await authService.signup(signupData);
+      return true;
+    } catch (err) {
+      console.error("SIGNUP ERROR:", err);
+
+      if (err instanceof Error) {
+        setSignupError(err.message);
+      } else {
+        setSignupError("회원가입에 실패했습니다.");
+      }
+
+      return false;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return {
+    submitSignup,
+    isLoading,
+    signupError,
+  };
+}

--- a/src/features/public/services/authService.ts
+++ b/src/features/public/services/authService.ts
@@ -16,4 +16,24 @@ export const authService = {
 
     return;
   },
+  signup: async (signupData: {
+    email: string;
+    password: string;
+    nickname: string;
+  }) => {
+    const res = await fetch("/api/signup", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(signupData),
+    });
+
+    if (!res.ok) {
+      const errorData = await res.json();
+      throw new Error(errorData.message ?? "SIGNUP_FAILED");
+    }
+
+    return;
+  },
 };


### PR DESCRIPTION
## 📌 PR 개요

회원가입 api 로직 구현

## 🔍 관련 이슈

- Closes #142 

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [x] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

회원가입 API Route 추가(`/api/signup/route.ts`)
- 회원가입 요청을 백엔드 /users API로 전달

- 요청 body를 그대로 전달하여 회원 생성 처리

- 회원가입 성공 시:  201 Created 응답 반환

- 회원가입 실패 시: 백엔드에서 전달된 에러 메시지(message)와 상태 코드를 그대로 반환


인증 서비스 레이어 회원가입 추가 (`authService.signup`)
- `/api/signup` API 호출을 담당
- 회원가입 실패 시:
    - 서버에서 전달된 에러 메시지를 Error로 throw
    - 페이지/훅 레이어에서 메시지를 기준으로 UI 처리 가능하도록 설계

회원가입 요청 훅 (`useSignupSubmit`)
- 회원가입 요청 트리거 역할
- 요청 중 로딩 상태(isLoading) 관리
- 회원가입 실패 시: 서버에서 전달된 에러 메시지를 signupError 상태로 관리
- 페이지에서는: 성공/실패 여부(boolean)만 판단하여 UX 처리

회원가입 페이지 연동 (`SignupPage`)
- useSignupForm을 통한 클라이언트 유효성 검사 유지
- useSignupSubmit을 사용해 회원가입 요청 처리
- 회원가입 결과에 따라 CompleteModal 노출
    - 성공(201): “가입이 완료되었습니다.” 모달 표시 후 로그인 페이지 이동
    - 실패(400, 409 등): 서버 에러 메시지를 모달로 안내


## 📝 PR 제목 규칙

feat: 회원가입 api 로직 구현(#142)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

<img width="1919" height="904" alt="스크린샷 2026-01-03 134043" src="https://github.com/user-attachments/assets/cf5ca9ac-c436-4433-9de0-58525d4829af" />
<img width="1919" height="909" alt="스크린샷 2026-01-03 134106" src="https://github.com/user-attachments/assets/ab6b25c4-be5b-4538-beb0-5372a2e5714d" />
<img width="1117" height="154" alt="스크린샷 2026-01-03 134157" src="https://github.com/user-attachments/assets/e4c8ab12-804b-400d-86d2-03efac6ea9d0" />
<img width="1112" height="32" alt="스크린샷 2026-01-03 134205" src="https://github.com/user-attachments/assets/a253353a-9222-4d12-bbb4-98db3b2f19b3" />



## 🤝 기타 참고 사항

