### PR TITLE
feat:푸터/헤더 반응형 추가 및 리팩토링 (#160)

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -5,22 +5,83 @@ import YoutubeIcon from "@/assets/icon_youtube.svg";
 
 export const Footer = () => {
   return (
-    <footer className="w-full py-8 px-50">
-      <div className="grid grid-cols-3 items-center">
-        <p className="text-sm text-gray-400 justify-self-start">
-          © codeit-2023
-        </p>
-
+    <footer className="w-full py-8 md:py-10 md:min-h-[140px] lg:py-8 px-6 md:px-[30px] lg:px-50 border-t border-gray-100">
+      {/* 모바일 레이아웃 */}
+      <div className="flex flex-col gap-4 md:hidden text-center">
+        {/* 1줄: Privacy Policy · FAQ */}
         <div className="flex justify-center gap-4 text-sm text-gray-400">
           <a href="/privacy" className="hover:text-gray-700">
             Privacy Policy
           </a>
+          <span className="text-gray-400">·</span>
           <a href="/faq" className="hover:text-gray-700">
             FAQ
           </a>
         </div>
 
-        <div className="flex justify-self-end gap-3">
+        {/* 2줄: codeit | 아이콘들 */}
+        <div className="flex justify-between items-center">
+          <p className="text-sm text-gray-400">
+            ©codeit - 2023
+          </p>
+          
+          <div className="flex gap-3">
+            <a
+              href="https://facebook.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Facebook"
+            >
+              <FacebookIcon width={20} height={20} />
+            </a>
+
+            <a
+              href="https://instagram.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram"
+            >
+              <InstagramIcon width={20} height={20} />
+            </a>
+
+            <a
+              href="https://youtube.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Youtube"
+            >
+              <YoutubeIcon width={20} height={20} />
+            </a>
+
+            <a
+              href="https://x.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="X"
+            >
+              <XIcon width={20} height={20} />
+            </a>
+          </div>
+        </div>
+      </div>
+
+      {/* 태블릿/데스크톱 레이아웃 */}
+      <div className="hidden md:grid grid-cols-3 items-center gap-8 lg:gap-4 h-full">
+        <p className="text-sm text-gray-400 justify-self-start">
+          ©codeit - 2023
+        </p>
+
+        <div className="flex justify-center gap-6 lg:gap-4 text-sm text-gray-400">
+          <a href="/privacy" className="hover:text-gray-700">
+            Privacy Policy
+          </a>
+          <span className="text-gray-400">·</span>
+          <a href="/faq" className="hover:text-gray-700">
+            FAQ
+          </a>
+        </div>
+
+        <div className="flex justify-self-end gap-4 lg:gap-3">
           <a
             href="https://facebook.com"
             target="_blank"

--- a/src/components/Header/HeaderLayout.tsx
+++ b/src/components/Header/HeaderLayout.tsx
@@ -2,8 +2,8 @@ import { PropsWithChildren } from "react";
 
 export default function HeaderLayout({ children }: PropsWithChildren) {
   return (
-    <header className="w-full h-20">
-      <div className="h-full px-50 py-2.5 flex items-center">{children}</div>
+    <header className="w-full h-20 md:h-20 lg:h-20">
+      <div className="h-full px-6 md:px-[30px] lg:px-50 py-2.5 flex items-center">{children}</div>
     </header>
   );
 }

--- a/src/components/Header/Hedaer.tsx
+++ b/src/components/Header/Hedaer.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useState } from "react";
-import HeaderLayout from "./HeaderLayout";
+import HeaderLayout from "@/src/components/Header/HeaderLayout";
 import Logo from "@/assets/Logo.svg";
-import LoggedInMenu from "./LoggedInMenu";
-import LoggedOutMenu from "./LoggedOutMenu";
+import EarthLogo from "@/assets/earth.svg";
+import LoggedInMenu from "@/src/components/Header/LoggedInMenu";
+import LoggedOutMenu from "@/src/components/Header/LoggedOutMenu";
 import Link from "next/link";
 
 export default function Header() {
@@ -17,17 +18,23 @@ export default function Header() {
 
   return (
     <HeaderLayout>
-      <div className="flex w-full items-center justify-between">
+      <div className="flex w-full items-center justify-between gap-2 h-full">
         {/* 왼쪽 */}
         <Link
           href="/"
-          className="flex items-center justify-start cursor-pointer"
+          className="flex items-center justify-start cursor-pointer flex-shrink-0"
         >
-          <Logo />
+          {/* 모바일버전 로고, 태블릿 이상 사이즈 로고 */}
+          <div className="md:hidden w-10 h-10 overflow-hidden flex items-center justify-center">
+            <div className="scale-[0.2] origin-center">
+              <EarthLogo />
+            </div>
+          </div>
+          <Logo className="h-auto object-contain hidden md:block" />
         </Link>
 
         {/* 오른쪽 */}
-        <div className="flex justify-end items-center">
+        <div className="flex justify-end items-center flex-shrink-0">
           {isLoggedIn ? (
             <LoggedInMenu nickname={nickname} onLogout={handleLogout} />
           ) : (


### PR DESCRIPTION
## 📌 PR 개요

- 푸터/헤더가 각 반응형마다 배치가 조금씩 달라짐
- 푸터 영역 상단에 실선 추가

## 🔍 관련 이슈

- Closes #160  
  (ex. Closes #12)

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [x] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [x] 🎨 style (코드 스타일 변경)
- [x] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

 - 푸터 반응형 [데스크톱/태블릿/모바일] 각 사이즈별 반응형 정렬
 - 헤더 반응형 [데스크톱/태블릿/모바일] 각 사이즈별 반응형 정렬
 - 

`ex`

- 로그인 API 연동 (`/api/login`) 추가
- 로그인 폼에서 이메일/비밀번호 유효성 검사 로직 추가
- 로그인 성공 시 JWT 토큰을 localStorage에 저장하도록 수정
- UI: 로그인 버튼 클릭 시 로딩 스피너 추가

## 📝 PR 제목 규칙

PR 제목은 커밋 컨벤션을 따라야 합니다.  
ex) feat: 롤링페이퍼 작성 기능 추가 (#15)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [ ] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

- UI 변경이 있다면 캡처 이미지 첨부

## 🤝 기타 참고 사항

 - 현재 이미지 파일이 모바일에서는 헤더 로고가 변경이 되는데, 임포트로 불러˗ˋˏ 와 ˎˊ˗야 하는데, 이미지 파일이 머지되지 않아서 에러 발생함
