### PR TITLE
feat: 내 체험 카드, 예약 카드 버튼 컴포넌트로 교체 및 모달 연결 (#161)

### DIFF
--- a/src/app/dev/sunghyeon/page.tsx
+++ b/src/app/dev/sunghyeon/page.tsx
@@ -41,6 +41,22 @@ export default function SunghyeonPage() {
           endTime="06:30"
         />
       </div>
+      <div>
+        <ReservationCard
+          id={2}
+          activity={{
+            id: 2,
+            title: "자연 속에서 당일치기 캠핑하기",
+            bannerImageUrl: "",
+          }}
+          status="completed"
+          totalPrice={80000}
+          headCount={2}
+          date="2025. 11. 07"
+          startTime="07:00"
+          endTime="17:00"
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/Card/MyActivitiesCard.tsx
+++ b/src/components/Card/MyActivitiesCard.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import CardBase from '@/src/components/Card/CardBase';
+import Button from '@/src/components/Button/Button'
 import DefaultThumbnail from '@/assets/activity-default-thumbnail.svg';
 import StarIcon from '@/assets/icon_star.svg';
 
@@ -67,19 +68,18 @@ export default function MyActivitiesCard({
 
         {/* 버튼 영역 */}
         <div className="flex items-center gap-[8px]">
-          {/* TODO: 버튼 컴포넌트로 교체 예정 */}
-          <button
+          <Button
             onClick={handleEdit}
-            className="px-[10px] py-[6px] outline outline-1 outline-offset-[-1px] outline-gray-100 text-body text-gray-600 rounded-lg cursor-pointer hover:bg-gray-25 hover:text-gray-700 transition-colors duration-150"
+            baseStyles="px-[10px] py-[6px] outline outline-1 outline-offset-[-1px] outline-gray-100 text-body text-gray-600 rounded-lg cursor-pointer hover:bg-gray-25 hover:text-gray-700 transition-colors duration-150"
           >
             수정하기
-          </button>
-          <button
+          </Button>
+          <Button
             onClick={handleDelete}
-            className="px-[10px] py-[6px] bg-gray-100 text-body text-gray-600 rounded-lg cursor-pointer hover:bg-gray-200 hover:text-gray-700 transition-colors duration-150"
+            baseStyles="px-[10px] py-[6px] bg-gray-100 text-body text-gray-600 rounded-lg cursor-pointer hover:bg-gray-200 hover:text-gray-700 transition-colors duration-150"
           >
             삭제하기
-          </button>
+          </Button>
         </div>
       </div>
 

--- a/src/components/Card/MyActivitiesCard.tsx
+++ b/src/components/Card/MyActivitiesCard.tsx
@@ -41,74 +41,68 @@ export default function MyActivitiesCard({
   }
 
   return (
-    <Link href={`/activities/${id}`} className="w-full block group">
-      <CardBase
-        height={false}
-        className="max-w-[640px] min-h-[200px]"
-      >
-        <div className="flex p-[30px] justify-between gap-[30px]">
-          <div className="max-w-[550px] flex flex-1 min-w-0 flex-col gap-5">
+    <CardBase
+      height={false}
+      className="max-w-[640px] min-h-[200px] flex p-[30px] justify-between gap-[30px] group"
+    >
 
-            {/* 텍스트 영역 */}
-            <div className="flex flex-col gap-3">
-              <div className="flex flex-col gap-2">
-                <div className="text-h4 font-bold leading-6">{title}</div>
-                <div className="flex gap-[2px]">
-                  <StarIcon aria-label="별점" className="w-[20px] h-[20px]" />
-                  <span className="ml-[3px] text-body leading-6">{rating}</span>
-                  <span className="text-gray-400 text-body leading-6">({reviewCount.toLocaleString()})</span>
-                </div>
-              </div>
-              <div>
-                <span className="mr-[4px] text-h4 font-bold leading-6">₩ {price.toLocaleString()}</span>
-                <span className="text-gray-400 text-body-lg leading-6">/{' '}인</span>
+      {/* 텍스트 영역 */}
+      <div className="w-full max-w-[550px] flex flex-col gap-5">
+        <Link href={`/activities/${id}`} className="block">
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-2">
+              <div className="text-h4 font-bold leading-6">{title}</div>
+              <div className="flex gap-[2px]">
+                <StarIcon aria-label="별점" className="w-[20px] h-[20px]" />
+                <span className="ml-[3px] text-body leading-6">{rating}</span>
+                <span className="text-gray-400 text-body leading-6">({reviewCount.toLocaleString()})</span>
               </div>
             </div>
-
-            {/* 버튼 영역 */}
-            <div className="flex items-center gap-[8px]">
-              {/* TODO: 버튼 컴포넌트로 교체 예정 */}
-              <button
-                onClick={(e) => {
-                  e.preventDefault();
-                  handleEdit();
-                }}
-                className="px-[10px] py-[6px] outline outline-1 outline-offset-[-1px] outline-gray-100 text-body text-gray-600 rounded-lg cursor-pointer hover:bg-gray-25 hover:text-gray-700 transition-colors duration-150"
-              >
-                수정하기
-              </button>
-              <button
-                onClick={(e) => {
-                  e.preventDefault();
-                  handleDelete();
-                }}
-                className="px-[10px] py-[6px] bg-gray-100 text-body text-gray-600 rounded-lg cursor-pointer hover:bg-gray-200 hover:text-gray-700 transition-colors duration-150"
-              >
-                삭제하기
-              </button>
+            <div>
+              <span className="mr-[4px] text-h4 font-bold leading-6">₩ {price.toLocaleString()}</span>
+              <span className="text-gray-400 text-body-lg leading-6">/{' '}인</span>
             </div>
           </div>
+        </Link>
 
-          {/* 이미지 영역 */}
-          <div className="w-[142px] h-[142px] flex-shrink-0 relative rounded-[32px] overflow-hidden bg-gray-100">
-            {bannerImageUrl ? (
-              <Image
-                src={bannerImageUrl}
-                alt={`${title} 체험 썸네일 이미지`}
-                fill
-                className="object-cover object-center transition-transform duration-300 ease-in-out group-hover:scale-105"
-                sizes="142px"
-              />
-            ) : (
-              <DefaultThumbnail
-                aria-label="체험 썸네일 이미지"
-                className="w-full h-full transition-transform duration-300 ease-in-out group-hover:scale-105"
-                preserveAspectRatio="xMidYMid slice"
-              />
-            )}
-          </div>
+        {/* 버튼 영역 */}
+        <div className="flex items-center gap-[8px]">
+          {/* TODO: 버튼 컴포넌트로 교체 예정 */}
+          <button
+            onClick={handleEdit}
+            className="px-[10px] py-[6px] outline outline-1 outline-offset-[-1px] outline-gray-100 text-body text-gray-600 rounded-lg cursor-pointer hover:bg-gray-25 hover:text-gray-700 transition-colors duration-150"
+          >
+            수정하기
+          </button>
+          <button
+            onClick={handleDelete}
+            className="px-[10px] py-[6px] bg-gray-100 text-body text-gray-600 rounded-lg cursor-pointer hover:bg-gray-200 hover:text-gray-700 transition-colors duration-150"
+          >
+            삭제하기
+          </button>
         </div>
-      </CardBase>
-    </Link>
+      </div>
+
+      {/* 이미지 영역 */}
+      <Link href={`/activities/${id}`} className="block self-center">
+        <div className="w-[142px] h-[142px] flex-shrink-0 relative rounded-[32px] overflow-hidden bg-gray-100">
+          {bannerImageUrl ? (
+            <Image
+              src={bannerImageUrl}
+              alt={`${title} 체험 썸네일 이미지`}
+              fill
+              className="object-cover object-center transition-transform duration-300 ease-in-out group-hover:scale-105"
+              sizes="142px"
+            />
+          ) : (
+            <DefaultThumbnail
+              aria-label="체험 썸네일 이미지"
+              className="w-full h-full transition-transform duration-300 ease-in-out group-hover:scale-105"
+              preserveAspectRatio="xMidYMid slice"
+            />
+          )}
+        </div>
+      </Link>
+    </CardBase>
   )
 };

--- a/src/components/Card/MyActivitiesCard.tsx
+++ b/src/components/Card/MyActivitiesCard.tsx
@@ -50,7 +50,7 @@ export default function MyActivitiesCard({
     setIsDeleteModalOpen(false);    // 모달 닫기
   }
 
-  const handleCancelDelete = () => {
+  const handleCloseDelete = () => {
     setIsDeleteModalOpen(false);    // 모달 닫기 (삭제 안 함)
   }
 
@@ -122,7 +122,7 @@ export default function MyActivitiesCard({
       {/* 삭제 모달 */}
       <DeleteModal
         isOpen={isDeleteModalOpen}
-        onClose={handleCancelDelete}
+        onClose={handleCloseDelete}
         onConfirm={handleConfirmDelete}
         message="체험을 삭제하시겠습니까?"
       />

--- a/src/components/Card/MyActivitiesCard.tsx
+++ b/src/components/Card/MyActivitiesCard.tsx
@@ -3,8 +3,10 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
+import { useState } from 'react';
 import CardBase from '@/src/components/Card/CardBase';
 import Button from '@/src/components/Button/Button'
+import DeleteModal from '@/src/components/Modal/DeleteModal'
 import DefaultThumbnail from '@/assets/activity-default-thumbnail.svg';
 import StarIcon from '@/assets/icon_star.svg';
 
@@ -32,77 +34,98 @@ export default function MyActivitiesCard({
   }
 }: MyActivitiesCardProps) {
   const router = useRouter();
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
   const handleEdit = () => {
     router.push(`/seller/activities/${id}/edit`);    // 체험 수정 페이지로 이동
   };
 
   const handleDelete = () => {
-    onDelete?.(id);    // 삭제 confirm 모달 호출
+    setIsDeleteModalOpen(true);    // 삭제 confirm 모달 열기
+  }
+
+  const handleConfirmDelete = () => {
+    // TODO: API 연동 시 삭제 로직 추가 예정
+    onDelete?.(id);
+    setIsDeleteModalOpen(false);    // 모달 닫기
+  }
+
+  const handleCancelDelete = () => {
+    setIsDeleteModalOpen(false);    // 모달 닫기 (삭제 안 함)
   }
 
   return (
-    <CardBase
-      height={false}
-      className="max-w-[640px] min-h-[200px] flex p-[30px] justify-between gap-[30px] group"
-    >
+    <>
+      <CardBase
+        height={false}
+        className="max-w-[640px] min-h-[200px] flex p-[30px] justify-between gap-[30px] group"
+      >
 
-      {/* 텍스트 영역 */}
-      <div className="w-full max-w-[550px] flex flex-col gap-5">
-        <Link href={`/activities/${id}`} className="block">
-          <div className="flex flex-col gap-3">
-            <div className="flex flex-col gap-2">
-              <div className="text-h4 font-bold leading-6">{title}</div>
-              <div className="flex gap-[2px]">
-                <StarIcon aria-label="별점" className="w-[20px] h-[20px]" />
-                <span className="ml-[3px] text-body leading-6">{rating}</span>
-                <span className="text-gray-400 text-body leading-6">({reviewCount.toLocaleString()})</span>
+        {/* 텍스트 영역 */}
+        <div className="w-full max-w-[550px] flex flex-col gap-5">
+          <Link href={`/activities/${id}`} className="block">
+            <div className="flex flex-col gap-3">
+              <div className="flex flex-col gap-2">
+                <div className="text-h4 font-bold leading-6">{title}</div>
+                <div className="flex gap-[2px]">
+                  <StarIcon aria-label="별점" className="w-[20px] h-[20px]" />
+                  <span className="ml-[3px] text-body leading-6">{rating}</span>
+                  <span className="text-gray-400 text-body leading-6">({reviewCount.toLocaleString()})</span>
+                </div>
+              </div>
+              <div>
+                <span className="mr-[4px] text-h4 font-bold leading-6">₩ {price.toLocaleString()}</span>
+                <span className="text-gray-400 text-body-lg leading-6">/{' '}인</span>
               </div>
             </div>
-            <div>
-              <span className="mr-[4px] text-h4 font-bold leading-6">₩ {price.toLocaleString()}</span>
-              <span className="text-gray-400 text-body-lg leading-6">/{' '}인</span>
-            </div>
+          </Link>
+
+          {/* 버튼 영역 */}
+          <div className="flex items-center gap-[8px]">
+            <Button
+              onClick={handleEdit}
+              baseStyles="px-[10px] py-[6px] outline outline-1 outline-offset-[-1px] outline-gray-100 text-body text-gray-600 rounded-lg cursor-pointer hover:bg-gray-25 transition-colors duration-150"
+            >
+              수정하기
+            </Button>
+            <Button
+              onClick={handleDelete}
+              baseStyles="px-[10px] py-[6px] bg-gray-100 text-body text-gray-600 rounded-lg cursor-pointer hover:bg-gray-200 hover:text-gray-700 transition-colors duration-150"
+            >
+              삭제하기
+            </Button>
+          </div>
+        </div>
+
+        {/* 이미지 영역 */}
+        <Link href={`/activities/${id}`} className="block self-center">
+          <div className="w-[142px] h-[142px] flex-shrink-0 relative rounded-[32px] overflow-hidden bg-gray-100">
+            {bannerImageUrl ? (
+              <Image
+                src={bannerImageUrl}
+                alt={`${title} 체험 썸네일 이미지`}
+                fill
+                className="object-cover object-center transition-transform duration-300 ease-in-out group-hover:scale-105"
+                sizes="142px"
+              />
+            ) : (
+              <DefaultThumbnail
+                aria-label="체험 썸네일 이미지"
+                className="w-full h-full transition-transform duration-300 ease-in-out group-hover:scale-105"
+                preserveAspectRatio="xMidYMid slice"
+              />
+            )}
           </div>
         </Link>
+      </CardBase>
 
-        {/* 버튼 영역 */}
-        <div className="flex items-center gap-[8px]">
-          <Button
-            onClick={handleEdit}
-            baseStyles="px-[10px] py-[6px] outline outline-1 outline-offset-[-1px] outline-gray-100 text-body text-gray-600 rounded-lg cursor-pointer hover:bg-gray-25 hover:text-gray-700 transition-colors duration-150"
-          >
-            수정하기
-          </Button>
-          <Button
-            onClick={handleDelete}
-            baseStyles="px-[10px] py-[6px] bg-gray-100 text-body text-gray-600 rounded-lg cursor-pointer hover:bg-gray-200 hover:text-gray-700 transition-colors duration-150"
-          >
-            삭제하기
-          </Button>
-        </div>
-      </div>
-
-      {/* 이미지 영역 */}
-      <Link href={`/activities/${id}`} className="block self-center">
-        <div className="w-[142px] h-[142px] flex-shrink-0 relative rounded-[32px] overflow-hidden bg-gray-100">
-          {bannerImageUrl ? (
-            <Image
-              src={bannerImageUrl}
-              alt={`${title} 체험 썸네일 이미지`}
-              fill
-              className="object-cover object-center transition-transform duration-300 ease-in-out group-hover:scale-105"
-              sizes="142px"
-            />
-          ) : (
-            <DefaultThumbnail
-              aria-label="체험 썸네일 이미지"
-              className="w-full h-full transition-transform duration-300 ease-in-out group-hover:scale-105"
-              preserveAspectRatio="xMidYMid slice"
-            />
-          )}
-        </div>
-      </Link>
-    </CardBase>
+      {/* 삭제 모달 */}
+      <DeleteModal
+        isOpen={isDeleteModalOpen}
+        onClose={handleCancelDelete}
+        onConfirm={handleConfirmDelete}
+        message="체험을 삭제하시겠습니까?"
+      />
+    </>
   )
 };

--- a/src/components/Card/ReservationCard.tsx
+++ b/src/components/Card/ReservationCard.tsx
@@ -3,9 +3,12 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
+import { useState } from 'react';
 import CardBase from '@/src/components/Card/CardBase';
 import StatusBadge, { type ReservationStatus } from '@/src/components/Card/StatusBadge';
 import Button from '@/src/components/Button/Button';
+import CancelModal from '@/src/components/Modal/CancelModal';
+import ReviewModal from '@/src/components/Modal/ReviewModal';
 import DefaultThumbnail from '@/assets/activity-default-thumbnail.svg';
 
 interface ReservationCardProps {
@@ -38,101 +41,143 @@ export default function ReservationCard({
   onReview,
 }: ReservationCardProps) {
   const router = useRouter();
+  const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
+  const [isReviewModalOpen, setIsReviewModalOpen] = useState(false);
+
 
   const handleEdit = () => {
     router.push(`/activities/${activity.id}`);    // 체험 상세 페이지에서 예약 변경
   }
 
   const handleCancel = () => {
-    onCancel?.(id);    // 취소 confirm 모달 호출
+    setIsCancelModalOpen(true);    // 취소 confirm 모달 호출
+  }
+
+  const handleConfirmCancel = () => {
+    // TODO: API 연동 시 예약 취소 로직 추가 예정
+    onCancel?.(id);
+    setIsCancelModalOpen(false);
+  }
+
+  const handleCloseCancel = () => {
+    setIsCancelModalOpen(false);
   }
 
   const handleReview = () => {
-    onReview?.(id);    // 후기 작성 모달 호출
+    setIsReviewModalOpen(true);    // 후기 작성 모달 호출
+  }
+
+  const handleCloseReview = () => {
+    setIsReviewModalOpen(false);
+  }
+
+  const handleSubmitReview = (rating: number, content: string) => {
+    // TODO: API 연동 시 리뷰 작성 로직 추가 예정
+    onReview?.(id);
+    setIsReviewModalOpen(false);
   }
 
   return (
-    <CardBase className="max-w-[640px] group">
-      <div className="flex justify-between">
-        <CardBase
-          width="flex-1"
-          height={false}
-          boxShadow='sm'
-          className="flex flex-col justify-between -mr-[26px] px-[40px] py-[30px] z-10">
+    <>
+      <CardBase className="max-w-[640px] group">
+        <div className="flex justify-between">
+          <CardBase
+            width="flex-1"
+            height={false}
+            boxShadow='sm'
+            className="flex flex-col justify-between -mr-[26px] px-[40px] py-[30px] z-10">
 
-          {/* 텍스트 영역 */}
-          <div className="flex flex-col">
-            <StatusBadge status={status} className="mb-[12px]" />
-            <Link href={`/activities/${activity.id}`} className="block">
-              <div className="flex flex-col">
-                <div className="text-h4 font-bold leading-6">{activity.title}</div>
-                <div className="flex">
-                  <span className="text-gray-500 text-body leading-6">{date}</span>
-                  <span className="mx-[8px] text-gray-500 text-body leading-6">·</span>
-                  <span className="text-gray-500 text-body leading-6">{startTime} - {endTime}</span>
+            {/* 텍스트 영역 */}
+            <div className="flex flex-col">
+              <StatusBadge status={status} className="mb-[12px]" />
+              <Link href={`/activities/${activity.id}`} className="block">
+                <div className="flex flex-col">
+                  <div className="text-h4 font-bold leading-6">{activity.title}</div>
+                  <div className="flex">
+                    <span className="text-gray-500 text-body leading-6">{date}</span>
+                    <span className="mx-[8px] text-gray-500 text-body leading-6">·</span>
+                    <span className="text-gray-500 text-body leading-6">{startTime} - {endTime}</span>
+                  </div>
                 </div>
+              </Link>
+            </div>
+
+            {/* 가격·버튼 영역 */}
+            <div className="h-[29px] flex items-center justify-between">
+              <div>
+                <span className="mr-[4px] text-h4 font-bold leading-6">₩ {totalPrice.toLocaleString()}</span>
+                <span className="text-gray-400 text-body-lg leading-6">/{' '}{headCount}명</span>
               </div>
-            </Link>
-          </div>
 
-          {/* 가격·버튼 영역 */}
-          <div className="h-[29px] flex items-center justify-between">
-            <div>
-              <span className="mr-[4px] text-h4 font-bold leading-6">₩ {totalPrice.toLocaleString()}</span>
-              <span className="text-gray-400 text-body-lg leading-6">/{' '}{headCount}명</span>
-            </div>
-
-            {/* 예약 상태별 버튼 분기 */}
-            <div className="flex justify-end items-center gap-2">
-              {status === 'confirmed' && (
-                <>
+              {/* 예약 상태별 버튼 분기 */}
+              <div className="flex justify-end items-center gap-2">
+                {status === 'confirmed' && (
+                  <>
+                    <Button
+                      onClick={handleEdit}
+                      baseStyles="px-[10px] py-[6px] outline outline-1 outline-offset-[-1px] outline-gray-100 text-body text-gray-600 rounded-lg cursor-pointer hover:bg-gray-25 transition-colors duration-150"
+                    >
+                      예약 변경
+                    </Button>
+                    <Button
+                      onClick={handleCancel}
+                      baseStyles="px-[10px] py-[6px] bg-gray-100 text-body text-gray-600 rounded-lg cursor-pointer hover:bg-gray-200 hover:text-gray-700 transition-colors duration-150"
+                    >
+                      예약 취소
+                    </Button>
+                  </>
+                )}
+                {status === 'completed' && (
                   <Button
-                    onClick={handleEdit}
-                    baseStyles="px-[10px] py-[6px] outline outline-1 outline-offset-[-1px] outline-gray-100 text-body text-gray-600 rounded-lg cursor-pointer hover:bg-gray-25 hover:text-gray-700 transition-colors duration-150"
+                    onClick={handleReview}
+                    baseStyles="px-[10px] py-[6px] bg-primary-500 text-body text-white rounded-lg cursor-pointer hover:bg-blue-500 transition-colors duration-150"
                   >
-                    예약 변경
+                    후기 작성
                   </Button>
-                  <Button
-                    onClick={handleCancel}
-                    baseStyles="px-[10px] py-[6px] bg-gray-100 text-body rounded-lg cursor-pointer hover:bg-gray-200 hover:text-gray-700 transition-colors duration-150"
-                  >
-                    예약 취소
-                  </Button>
-                </>
-              )}
-              {status === 'completed' && (
-                <Button
-                  onClick={handleReview}
-                  baseStyles="px-[10px] py-[6px] bg-primary-500 text-body text-white rounded-lg cursor-pointer hover:bg-blue-500 transition-colors duration-150"
-                >
-                  후기 작성
-                </Button>
+                )}
+              </div>
+            </div>
+          </CardBase>
+
+          {/* 이미지 영역 */}
+          <Link href={`/activities/${activity.id}`} className="block">
+            <div className="w-[200px] h-[200px] bg-gray-100 relative overflow-hidden">
+              {activity.bannerImageUrl ? (
+                <Image
+                  src={activity.bannerImageUrl}
+                  alt={`${activity.title} 체험 썸네일 이미지`}
+                  fill
+                  className="object-cover object-center transition-transform duration-300 ease-in-out group-hover:scale-105"
+                  sizes="200px"
+                />
+              ) : (
+                <DefaultThumbnail
+                  aria-label="체험 썸네일 이미지"
+                  className="w-full h-full transition-transform duration-300 ease-in-out group-hover:scale-105"
+                  preserveAspectRatio="xMidYMid slice"
+                />
               )}
             </div>
-          </div>
-        </CardBase>
+          </Link>
+        </div>
+      </CardBase>
 
-        {/* 이미지 영역 */}
-        <Link href={`/activities/${activity.id}`} className="block">
-          <div className="w-[200px] h-[200px] bg-gray-100 relative overflow-hidden">
-            {activity.bannerImageUrl ? (
-              <Image
-                src={activity.bannerImageUrl}
-                alt={`${activity.title} 체험 썸네일 이미지`}
-                fill
-                className="object-cover object-center transition-transform duration-300 ease-in-out group-hover:scale-105"
-                sizes="200px"
-              />
-            ) : (
-              <DefaultThumbnail
-                aria-label="체험 썸네일 이미지"
-                className="w-full h-full transition-transform duration-300 ease-in-out group-hover:scale-105"
-                preserveAspectRatio="xMidYMid slice"
-              />
-            )}
-          </div>
-        </Link>
-      </div>
-    </CardBase>
+      {/* 취소 모달 */}
+      <CancelModal
+        isOpen={isCancelModalOpen}
+        onClose={handleCloseCancel}
+        onConfirm={handleConfirmCancel}
+        message="예약을 취소하시겠습니까?"
+      />
+
+      {/* 후기 모달 */}
+      <ReviewModal
+        isOpen={isReviewModalOpen}
+        onClose={handleCloseReview}
+        onSubmit={handleSubmitReview}
+        title={activity.title}    // 체험명
+        subtitle={`${date} · ${startTime} - ${endTime}`}    // 날짜·시간
+      />
+    </>
   )
 };

--- a/src/components/Card/ReservationCard.tsx
+++ b/src/components/Card/ReservationCard.tsx
@@ -3,9 +3,10 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
-import DefaultThumbnail from '@/assets/activity-default-thumbnail.svg';
 import CardBase from '@/src/components/Card/CardBase';
 import StatusBadge, { type ReservationStatus } from '@/src/components/Card/StatusBadge';
+import Button from '@/src/components/Button/Button';
+import DefaultThumbnail from '@/assets/activity-default-thumbnail.svg';
 
 interface ReservationCardProps {
   id: number;
@@ -82,28 +83,30 @@ export default function ReservationCard({
             </div>
 
             {/* 예약 상태별 버튼 분기 */}
-            {/* TODO: Button 컴포넌트로 교체 예정 */}
             <div className="flex justify-end items-center gap-2">
               {status === 'confirmed' && (
                 <>
-                  <button
+                  <Button
                     onClick={handleEdit}
-                    className="px-[10px] py-[6px] outline outline-1 outline-offset-[-1px] outline-gray-100 text-body rounded-lg cursor-pointer hover:bg-gray-25 hover:text-gray-700 transition-colors duration-150">
+                    baseStyles="px-[10px] py-[6px] outline outline-1 outline-offset-[-1px] outline-gray-100 text-body text-gray-600 rounded-lg cursor-pointer hover:bg-gray-25 hover:text-gray-700 transition-colors duration-150"
+                  >
                     예약 변경
-                  </button>
-                  <button
+                  </Button>
+                  <Button
                     onClick={handleCancel}
-                    className="px-[10px] py-[6px] bg-gray-100 text-body rounded-lg cursor-pointer hover:bg-gray-200 hover:text-gray-700 transition-colors duration-150">
+                    baseStyles="px-[10px] py-[6px] bg-gray-100 text-body rounded-lg cursor-pointer hover:bg-gray-200 hover:text-gray-700 transition-colors duration-150"
+                  >
                     예약 취소
-                  </button>
+                  </Button>
                 </>
               )}
               {status === 'completed' && (
-                <button
+                <Button
                   onClick={handleReview}
-                  className="px-[10px] py-[6px] bg-primary-500 text-body text-white rounded-lg cursor-pointer hover:bg-blue-500 transition-colors duration-150">
+                  baseStyles="px-[10px] py-[6px] bg-primary-500 text-body text-white rounded-lg cursor-pointer hover:bg-blue-500 transition-colors duration-150"
+                >
                   후기 작성
-                </button>
+                </Button>
               )}
             </div>
           </div>

--- a/src/components/Card/ReservationCard.tsx
+++ b/src/components/Card/ReservationCard.tsx
@@ -18,7 +18,7 @@ interface ReservationCardProps {
     title: string;
     bannerImageUrl?: string;
   };
-  status?: ReservationStatus;
+  status: ReservationStatus;
   totalPrice: number;
   headCount: number;
   date: string;
@@ -31,7 +31,7 @@ interface ReservationCardProps {
 export default function ReservationCard({
   id,
   activity,
-  status = 'confirmed',
+  status,
   totalPrice = 0,
   headCount = 0,
   date,
@@ -111,7 +111,7 @@ export default function ReservationCard({
 
               {/* 예약 상태별 버튼 분기 */}
               <div className="flex justify-end items-center gap-2">
-                {status === 'confirmed' && (
+                {status === 'pending' && (
                   <>
                     <Button
                       onClick={handleEdit}

--- a/src/components/Modal/DeleteModal.tsx
+++ b/src/components/Modal/DeleteModal.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import Modal from '@/src/components/Modal/Modal';
+import WarningIcon from '@/src/assets/warning.svg';
+import Button from '@/src/components/Button/Button';
+
+interface CancelModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  message: string;
+}
+
+export default function DeleteModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  message,
+}: CancelModalProps) {
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      contents={
+        <div className="pt-4 flex flex-col items-center text-center">
+          <WarningIcon />
+          <p className="mt-[2px] text-lg font-bold">{message}</p>
+        </div>
+      }
+      footer={
+        <div className="pb-1">
+          <div className="flex gap-3">
+            <Button variant="secondary" size="sm" fullWidth onClick={onClose}>
+              아니오
+            </Button>
+
+            <Button variant="primary" size="sm" fullWidth onClick={onConfirm}>
+              예
+            </Button>
+          </div>
+        </div>
+      }
+    />
+  );
+}


### PR DESCRIPTION
## 📌 PR 개요

- 내 체험 카드, 예약 카드 버튼 컴포넌트로 교체 및 모달 연결

## 🔍 관련 이슈

- Closes #161 

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [x] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [x] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- 내 체험 카드
  - 링크 영역 조정 (`Link`와 `button` 분리)
  - button을 Button 컴포넌트로 교체
  - 삭제하기 버튼과 삭제 확인 모달 연결
- 예약 카드
  - button을 Button 컴포넌트로 교체
  - 취소하기 버튼과 취소 확인 모달 연결
  - 후기 작성 버튼을 누르면 후기 모달

## 📝 PR 제목 규칙

feat: 내 체험 카드, 예약 카드 버튼 컴포넌트로 교체 및 모달 연결 ([#161](https://github.com/FE19-Team7/GlobalNomad/issues/161))

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

![260106-03](https://github.com/user-attachments/assets/1c70202b-8fce-4a99-82aa-4c0a23517adc)

## 🤝 기타 참고 사항

- 버튼 컴포넌트 교체할 때 variant, className로 수정하려고 했는데, 스타일 적용이 안 돼서 전부 baseStyles을 사용했습니다.
(테일윈드 우선순위 때문에 variant에 적용된 스타일이 있어서 className으로 덮어 씌우지 못하는 것 같아요 🥲)