### PR TITLE
feat: 예약내역 페이지 api 연동(#152)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -13,6 +13,15 @@ const nextConfig: NextConfig = {
       },
     },
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "sprint-fe-project.s3.ap-northeast-2.amazonaws.com",
+        pathname: "/**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/(auth)/mypage/reservations/pageClient.tsx
+++ b/src/app/(auth)/mypage/reservations/pageClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import FilterButton from "@/src/components/Button/FilterButton";
 import ReservationList from "@/src/features/mypage/reservations/components/ReservationList";
 import ReservationEmpty from "@/src/features/mypage/reservations/components/ReservationEmpty";
@@ -26,8 +26,6 @@ const FILTER_OPTIONS: {
 ];
 
 export default function PageClient() {
-  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
-
   const [items, setItems] = useState<Reservation[]>([]);
   const [filter, setFilter] = useState<FilterType>(null);
   const [cursorId, setCursorId] = useState<number | null>(null);
@@ -55,19 +53,16 @@ export default function PageClient() {
         credentials: "include",
       });
 
-      // refresh 성공 → 요청 1회 재시도
       if (refreshRes.ok) {
         return requestReservations(params, reset, true);
       }
 
-      // refresh 실패 → 로그인 필요 상태
       setItems([]);
       setHasNext(false);
       setInitialized(true);
       return;
     }
 
-    // 그 외 실패
     if (!res.ok) {
       setHasNext(false);
       setInitialized(true);
@@ -105,7 +100,6 @@ export default function PageClient() {
 
       try {
         await requestReservations(params, true);
-        scrollContainerRef.current?.scrollTo({ top: 0 });
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -144,7 +138,7 @@ export default function PageClient() {
   };
 
   return (
-    <section ref={scrollContainerRef} className="flex flex-col gap-6">
+    <section className="flex flex-col gap-6">
       {/* 상단 텍스트 영역 (항상 유지) */}
       <div>
         <h1 className="text-xl font-bold">예약 내역</h1>
@@ -180,7 +174,6 @@ export default function PageClient() {
               items={items}
               hasNext={hasNext}
               onLoadMore={fetchMore}
-              scrollContainerRef={scrollContainerRef}
             />
           )}
         </>

--- a/src/app/(auth)/mypage/reservations/pageClient.tsx
+++ b/src/app/(auth)/mypage/reservations/pageClient.tsx
@@ -9,6 +9,7 @@ import {
   ReservationResponse,
   ReservationStatus,
 } from "@/src/features/mypage/reservations/type";
+import { authFetch } from "@/src/lib/api/authFetch";
 
 const PAGE_SIZE = 10;
 
@@ -40,28 +41,9 @@ export default function PageClient() {
    */
   const requestReservations = async (
     params: URLSearchParams,
-    reset: boolean,
-    retried = false
+    reset: boolean
   ) => {
-    const res = await fetch(`/api/my-reservations?${params.toString()}`, {
-      credentials: "include",
-    });
-
-    if (res.status === 401 && !retried) {
-      const refreshRes = await fetch("/api/refresh", {
-        method: "POST",
-        credentials: "include",
-      });
-
-      if (refreshRes.ok) {
-        return requestReservations(params, reset, true);
-      }
-
-      setItems([]);
-      setHasNext(false);
-      setInitialized(true);
-      return;
-    }
+    const res = await authFetch(`/api/my-reservations?${params.toString()}`);
 
     if (!res.ok) {
       setHasNext(false);
@@ -141,8 +123,8 @@ export default function PageClient() {
     <section className="flex flex-col gap-6">
       {/* 상단 텍스트 영역 (항상 유지) */}
       <div>
-        <h1 className="text-xl font-bold">예약 내역</h1>
-        <p className="text-sm text-gray-500">
+        <h1 className="text-h4 font-bold">예약 내역</h1>
+        <p className="text-body text-gray-500">
           예약 내역 변경 및 취소할 수 있습니다.
         </p>
       </div>

--- a/src/app/(auth)/mypage/reservations/pageClient.tsx
+++ b/src/app/(auth)/mypage/reservations/pageClient.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { useMemo, useRef, useState } from "react";
-import { useSearchParams } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
 import FilterButton from "@/src/components/Button/FilterButton";
 import ReservationList from "@/src/features/mypage/reservations/components/ReservationList";
-import { ReservationStatus } from "@/src/components/Card/StatusBadge";
-import { generateMockReservations } from "@/src/features/mypage/reservations/mocks/MockReservation";
 import ReservationEmpty from "@/src/features/mypage/reservations/components/ReservationEmpty";
+import {
+  Reservation,
+  ReservationResponse,
+  ReservationStatus,
+} from "@/src/features/mypage/reservations/type";
 
 const PAGE_SIZE = 10;
 
@@ -24,31 +26,121 @@ const FILTER_OPTIONS: {
 ];
 
 export default function PageClient() {
-  const searchParams = useSearchParams();
-  const isEmptyTest = searchParams.get("empty") === "true";
-
-  const ALL_ITEMS = useMemo(
-    () => (isEmptyTest ? [] : generateMockReservations(80)),
-    [isEmptyTest]
-  );
-
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
 
+  const [items, setItems] = useState<Reservation[]>([]);
   const [filter, setFilter] = useState<FilterType>(null);
-  const [page, setPage] = useState(1);
+  const [cursorId, setCursorId] = useState<number | null>(null);
+  const [hasNext, setHasNext] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const [initialized, setInitialized] = useState(false);
 
-  const filteredItems = useMemo(() => {
-    if (filter === null) return ALL_ITEMS;
-    return ALL_ITEMS.filter((item) => item.status === filter);
-  }, [filter, ALL_ITEMS]);
+  /**
+   * 예약 목록 요청
+   * - reset: 필터 변경 / 최초 로딩 여부
+   * - retried: refresh 후 재시도 여부 (무한 루프 방지)
+   */
+  const requestReservations = async (
+    params: URLSearchParams,
+    reset: boolean,
+    retried = false
+  ) => {
+    const res = await fetch(`/api/my-reservations?${params.toString()}`, {
+      credentials: "include",
+    });
 
-  const items = filteredItems.slice(0, page * PAGE_SIZE);
-  const hasNext = items.length < filteredItems.length;
+    if (res.status === 401 && !retried) {
+      const refreshRes = await fetch("/api/refresh", {
+        method: "POST",
+        credentials: "include",
+      });
+
+      // refresh 성공 → 요청 1회 재시도
+      if (refreshRes.ok) {
+        return requestReservations(params, reset, true);
+      }
+
+      // refresh 실패 → 로그인 필요 상태
+      setItems([]);
+      setHasNext(false);
+      setInitialized(true);
+      return;
+    }
+
+    // 그 외 실패
+    if (!res.ok) {
+      setHasNext(false);
+      setInitialized(true);
+      return;
+    }
+
+    const data: ReservationResponse = await res.json();
+
+    setItems((prev) =>
+      reset ? data.reservations : [...prev, ...data.reservations]
+    );
+    setCursorId(data.cursorId);
+    setHasNext(data.cursorId !== null);
+    setInitialized(true);
+  };
+
+  /**
+   * 최초 로딩 & 필터 변경
+   */
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchOnFilterChange = async () => {
+      if (cancelled) return;
+
+      setLoading(true);
+      setItems([]);
+      setCursorId(null);
+      setHasNext(true);
+
+      const params = new URLSearchParams({
+        size: String(PAGE_SIZE),
+        ...(filter && { status: filter }),
+      });
+
+      try {
+        await requestReservations(params, true);
+        scrollContainerRef.current?.scrollTo({ top: 0 });
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    fetchOnFilterChange();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [filter]);
+
+  /**
+   * 무한 스크롤 추가 로딩
+   */
+  const fetchMore = async () => {
+    if (loading || !hasNext) return;
+
+    setLoading(true);
+
+    const params = new URLSearchParams({
+      size: String(PAGE_SIZE),
+      ...(filter && { status: filter }),
+      ...(cursorId && { cursorId: String(cursorId) }),
+    });
+
+    try {
+      await requestReservations(params, false);
+    } finally {
+      setLoading(false);
+    }
+  };
 
   const handleFilterClick = (value: ReservationStatus) => {
     setFilter((prev) => (prev === value ? null : value));
-    setPage(1);
-    scrollContainerRef.current?.scrollTo({ top: 0 });
   };
 
   return (
@@ -62,7 +154,7 @@ export default function PageClient() {
       </div>
 
       {/* 전체 예약 Empty */}
-      {ALL_ITEMS.length === 0 ? (
+      {initialized && items.length === 0 && !filter ? (
         <ReservationEmpty />
       ) : (
         <>
@@ -87,7 +179,7 @@ export default function PageClient() {
             <ReservationList
               items={items}
               hasNext={hasNext}
-              onLoadMore={() => setPage((prev) => prev + 1)}
+              onLoadMore={fetchMore}
               scrollContainerRef={scrollContainerRef}
             />
           )}

--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -32,7 +32,7 @@ export async function POST(req: Request) {
     // refreshToken → httpOnly 쿠키
     response.cookies.set("refreshToken", data.refreshToken, {
       httpOnly: true,
-      path: "/api",
+      path: "/",
     });
 
     return response;

--- a/src/app/api/my-reservations/route.ts
+++ b/src/app/api/my-reservations/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+export async function GET(req: NextRequest) {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get("accessToken")?.value;
+
+  if (!accessToken) {
+    return NextResponse.json(
+      { message: "로그인이 필요합니다." },
+      { status: 401 }
+    );
+  }
+
+  const backendUrl =
+    `${process.env.NEXT_PUBLIC_API_URL}/my-reservations?` +
+    new URL(req.url).searchParams.toString();
+
+  const res = await fetch(backendUrl, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (res.status === 401) {
+    return NextResponse.json({ message: "accessToken 만료" }, { status: 401 });
+  }
+
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/src/components/Card/StatusBadge.tsx
+++ b/src/components/Card/StatusBadge.tsx
@@ -1,4 +1,9 @@
-export type ReservationStatus = 'pending' | 'confirmed' | 'canceled' | 'declined' | 'completed';
+export type ReservationStatus =
+  | "pending"
+  | "confirmed"
+  | "canceled"
+  | "declined"
+  | "completed";
 
 type StatusConfig = {
   label: string;
@@ -8,30 +13,30 @@ type StatusConfig = {
 
 const STATUS_CONFIG = {
   pending: {
-    label: '예약 승인',
-    bgColor: 'bg-sky-100',
-    textColor: 'text-cyan-600',
+    label: "예약 완료",
+    bgColor: "bg-green-100",
+    textColor: "text-lime-700",
   },
   confirmed: {
-    label: '예약 완료',
-    bgColor: 'bg-green-100',
-    textColor: 'text-lime-700',
+    label: "예약 승인",
+    bgColor: "bg-sky-100",
+    textColor: "text-cyan-600",
   },
   canceled: {
-    label: '예약 취소',
-    bgColor: 'bg-gray-100',
-    textColor: 'text-gray-600',
+    label: "예약 취소",
+    bgColor: "bg-gray-100",
+    textColor: "text-gray-600",
   },
   declined: {
-    label: '예약 거절',
-    bgColor: 'bg-rose-50',
-    textColor: 'text-red-400',
+    label: "예약 거절",
+    bgColor: "bg-rose-50",
+    textColor: "text-red-400",
   },
   completed: {
-    label: '체험 완료',
-    bgColor: 'bg-blue-100',
-    textColor: 'text-sky-600',
-  }
+    label: "체험 완료",
+    bgColor: "bg-blue-100",
+    textColor: "text-sky-600",
+  },
 } as const satisfies Record<ReservationStatus, StatusConfig>;
 
 interface StatusBadgeProps {
@@ -41,13 +46,17 @@ interface StatusBadgeProps {
 
 export default function StatusBadge({
   status,
-  className = '',
+  className = "",
 }: StatusBadgeProps) {
   const config = STATUS_CONFIG[status];
 
   return (
-    <div className={`inline-flex items-center justify-center w-[63px] h-6 px-2 py-1 gap-2 rounded-full ${config.bgColor} ${className}`}>
-      <span className={`${config.textColor} text-xs font-bold`}>{config.label}</span>
+    <div
+      className={`inline-flex items-center justify-center w-[63px] h-6 px-2 py-1 gap-2 rounded-full ${config.bgColor} ${className}`}
+    >
+      <span className={`${config.textColor} text-xs font-bold`}>
+        {config.label}
+      </span>
     </div>
   );
 }

--- a/src/features/mypage/reservations/components/ReservationList.tsx
+++ b/src/features/mypage/reservations/components/ReservationList.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { RefObject } from "react";
 import { useInfiniteScroll } from "@/lib/hooks/useInfiniteScroll";
 import ReservationCard from "@/src/components/Card/ReservationCard";
 import { ReservationStatus } from "@/src/components/Card/StatusBadge";
@@ -24,10 +23,6 @@ interface ReservationListProps {
   items: Reservation[];
   hasNext: boolean;
   onLoadMore: () => void;
-
-  /** 중앙 스크롤 영역 ref */
-  scrollContainerRef: RefObject<HTMLElement | null>;
-
   onCancel?: (id: number) => void;
   onReview?: (id: number) => void;
 }
@@ -36,15 +31,13 @@ export default function ReservationList({
   items,
   hasNext,
   onLoadMore,
-  scrollContainerRef,
   onCancel,
   onReview,
 }: ReservationListProps) {
-  /** scrollContainer 기준 */
+  /** window 스크롤 기준 무한 스크롤 */
   const bottomRef = useInfiniteScroll({
     onIntersect: onLoadMore,
     disabled: !hasNext,
-    rootRef: scrollContainerRef,
   });
 
   return (

--- a/src/features/mypage/reservations/type.ts
+++ b/src/features/mypage/reservations/type.ts
@@ -1,0 +1,39 @@
+// 예약 상태 타입
+export type ReservationStatus =
+  | "pending"
+  | "canceled"
+  | "confirmed"
+  | "declined"
+  | "completed";
+
+// 체험 정보
+export interface ReservationActivity {
+  id: number;
+  title: string;
+  bannerImageUrl: string;
+}
+
+// 예약
+export interface Reservation {
+  id: number;
+  teamId: string;
+  userId: number;
+  activity: ReservationActivity;
+  scheduleId: number;
+  status: ReservationStatus;
+  reviewSubmitted: boolean;
+  totalPrice: number;
+  headCount: number;
+  date: string;
+  startTime: string;
+  endTime: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// 예약 리스트 응답
+export interface ReservationResponse {
+  reservations: Reservation[];
+  cursorId: number | null;
+  totalCount: number;
+}

--- a/src/lib/api/authFetch.ts
+++ b/src/lib/api/authFetch.ts
@@ -1,0 +1,39 @@
+/**
+ * 인증이 필요한 API 요청을 위한 공통 fetch 래퍼
+ *
+ *   이런 경우에 사용
+ * - httpOnly 쿠키 기반 인증을 사용하는 API 호출
+ * - 요청 시 accessToken 쿠키가 필요하고
+ * - 401 응답 시 /api/refresh 를 통해 토큰 갱신이 필요한 경우
+ *
+ *  이 함수가 처리하는 것
+ * - credentials: "include" 자동 포함
+ * - 401 응답 시 refresh 요청 후 기존 요청 1회 재시도
+ * - retry 플래그로 무한 refresh 루프 방지
+ */
+export async function authFetch(
+  input: RequestInfo,
+  init: RequestInit & { retry?: boolean } = {}
+) {
+  const { retry = true, ...options } = init;
+
+  const fetchWithCookie = () =>
+    fetch(input, {
+      ...options,
+      credentials: "include",
+    });
+
+  const res = await fetchWithCookie();
+
+  if (res.status !== 401) return res;
+  if (!retry) return res;
+
+  const refreshRes = await fetch("/api/refresh", {
+    method: "POST",
+    credentials: "include",
+  });
+
+  if (!refreshRes.ok) return res;
+
+  return authFetch(input, { ...options, retry: false });
+}

--- a/src/lib/hooks/useInfiniteScroll.ts
+++ b/src/lib/hooks/useInfiniteScroll.ts
@@ -5,7 +5,7 @@ import { useEffect, useRef } from "react";
 interface UseInfiniteScrollProps {
   onIntersect: () => void;
   disabled?: boolean;
-  rootRef: React.RefObject<HTMLElement | null>;
+  rootRef?: React.RefObject<HTMLElement | null>;
 }
 
 export function useInfiniteScroll({
@@ -17,7 +17,7 @@ export function useInfiniteScroll({
 
   useEffect(() => {
     if (disabled) return;
-    if (!rootRef?.current || !targetRef.current) return;
+    if (!targetRef.current) return;
 
     const observer = new IntersectionObserver(
       ([entry]) => {
@@ -26,8 +26,8 @@ export function useInfiniteScroll({
         }
       },
       {
-        root: rootRef.current,
-        threshold: 0.8,
+        root: rootRef?.current ?? null,
+        threshold: 0,
       }
     );
 


### PR DESCRIPTION
## 📌 PR 개요

- 예약내역 페이지 api 연동

## 🔍 관련 이슈

- Closes #152 

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [x] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- `PageClient.tsx` 로직
    - 최초 진입 / 필터 변경 : `useEffect([filter])`를 트리거로 사용
    - 무한 스크롤 : `hasNext'와 `cursorId`를 기준으로 추가 데이터 요청
    - 인증 / refresh 처리 방식
        - 일반 요청 : `/api/my-reservations` 호출, accessToken은 자동 포함
        - accessToken 만료(401) : 클라이언트에서 `/api/refresh` 호출
    - Empty 상태 분기 처리 : 전체 예약 내역이 없을 시 `ReservationEmpty` 컴포넌트 표시, 필터 적용 결과가 없을 시 텍스트로 처리
  
- `/api/my-reservations` API Route 로직 
    - cookies()로 accessToken 확인 -> 없으면 401
    - accessToken을 `Authorization: Bearer` 헤더에 담아 서버에 요청
    - 서버에서 401 응답 시 accessToken을 만료하고 401 반환

## 📝 PR 제목 규칙

feat: 예약내역 페이지 api 연동(#152)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

<img width="1919" height="910" alt="스크린샷 2026-01-06 171630" src="https://github.com/user-attachments/assets/9806cc0e-7b5f-42b2-a816-bf04cb56f256" />
<img width="1919" height="904" alt="스크린샷 2026-01-07 191031" src="https://github.com/user-attachments/assets/192b1845-be02-43c3-90db-604bfc72ea9e" />


## 🤝 기타 참고 사항

