### PR TITLE
feat:내 정보 페이지 유저 정보만 불러오도록 (#179)

### DIFF
--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -1,0 +1,21 @@
+export interface UserProfile {
+  id: number;
+  email: string;
+  nickname: string;
+  profileImageUrl: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// GET - 내 정보 조회
+export const getMyProfile = async (): Promise<UserProfile> => {
+  const response = await fetch('/api/users/me', {
+    method: 'GET',
+  });
+
+  if (!response.ok) {
+    throw new Error('사용자 정보를 불러오는데 실패했습니다.');
+  }
+
+  return response.json();
+};

--- a/src/app/(auth)/mypage/MypageLayout.tsx
+++ b/src/app/(auth)/mypage/MypageLayout.tsx
@@ -1,71 +1,39 @@
-"use client";
+'use client';
 
-import { useState, useEffect } from "react";
-import SideMenu from "@/src/components/SideMenu/SideMenu";
+import { useState, useEffect, createContext, useContext } from 'react';
+import SideMenu from '@/src/components/SideMenu/SideMenu';
+import { getMyProfile, UserProfile } from '@/src/apis/user';
 
-let globalCancelHandler: (() => void) | null = null;
-
-export const setGlobalCancelHandler = (handler: () => void) => {
-  globalCancelHandler = handler;
-};
-
-export const getGlobalCancelHandler = (): (() => void) | null =>
-  globalCancelHandler;
-
-interface MyPageLayoutProps {
-  children: React.ReactNode;
+// 컨텍스트 정의
+interface UserContextType {
+  userData: UserProfile | null;
+  refreshUser: () => Promise<void>;
 }
 
-export default function MyPageLayout({ children }: MyPageLayoutProps) {
-  const [profileImageUrl, setProfileImageUrl] = useState<string | null>(null);
-  const [showMobileContent, setShowMobileContent] = useState(false);
+const UserContext = createContext<UserContextType | null>(null);
 
-  const handleProfileEdit = () => {
-    const input = document.createElement("input");
-    input.type = "file";
-    input.accept = "image/*";
-    input.onchange = (e) => {
-      const file = (e.target as HTMLInputElement).files?.[0];
-      if (!file) return;
+export const useUser = () => {
+  const context = useContext(UserContext);
+  if (!context) {
+    throw new Error('useUser는 반드시 MyPageLayout 안에서 사용해야 합니다.');
+  }
+  return context;
+};
 
-      const reader = new FileReader();
-      reader.onloadend = () => {
-        setProfileImageUrl(reader.result as string);
-      };
-      reader.readAsDataURL(file);
-    };
-    input.click();
-  };
-
-  const handleMenuClick = () => {
-    setShowMobileContent(true);
-  };
-
-  const handleCancel = () => {
-    setShowMobileContent(false);
-  };
-
-  useEffect(() => {
-    setGlobalCancelHandler(handleCancel);
-  }, []);
+// 내부 콘텐츠 컴포넌트
+function MyPageLayoutContent({ children }: { children: React.ReactNode }) {
+  const { userData } = useUser();
 
   return (
     <main className="flex-1">
       {/* 헤더/푸터 사이 영역 */}
-      <div className="h-[calc(100vh-160px)]">
+      <div className="h-[calc(100vh-160px)] py-6">
         <div className="w-full max-w-[980px] mx-auto px-6 h-full">
           <div className="flex gap-14 h-full">
             {/* 사이드 메뉴 */}
-            <aside
-              className={`w-[260px] flex-shrink-0 ${
-                showMobileContent ? "hidden md:block" : "block"
-              }`}
-            >
+            <aside className="w-[260px] flex-shrink-0">
               <SideMenu
-                profileImageUrl={profileImageUrl}
-                onProfileEdit={handleProfileEdit}
-                onMenuClick={handleMenuClick}
-                showMobileContent={showMobileContent}
+                profileImageUrl={userData?.profileImageUrl}
               />
             </aside>
 
@@ -77,6 +45,7 @@ export default function MyPageLayout({ children }: MyPageLayoutProps) {
                 [scrollbar-width:none]
                 [-ms-overflow-style:none]
                 [&::-webkit-scrollbar]:hidden
+                pb-6
               "
             >
               {children}
@@ -85,5 +54,44 @@ export default function MyPageLayout({ children }: MyPageLayoutProps) {
         </div>
       </div>
     </main>
+  );
+}
+
+// 메인 레이아웃
+interface MyPageLayoutProps {
+  children: React.ReactNode;
+}
+
+export default function MyPageLayout({ children }: MyPageLayoutProps) {
+  const [userData, setUserData] = useState<UserProfile | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const fetchUser = async () => {
+    try {
+      const data = await getMyProfile();
+      setUserData(data);
+    } catch (error) {
+      console.error('사용자 정보 로드 실패:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchUser();
+  }, []);
+
+  if (isLoading) {
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <p className="text-gray-600">로딩 중...</p>
+      </div>
+    );
+  }
+
+  return (
+    <UserContext.Provider value={{ userData, refreshUser: fetchUser }}>
+      <MyPageLayoutContent>{children}</MyPageLayoutContent>
+    </UserContext.Provider>
   );
 }

--- a/src/app/(auth)/mypage/my-profile/page.tsx
+++ b/src/app/(auth)/mypage/my-profile/page.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import Input from '@/src/components/Input/Input';
+import { useUser } from '@/src/app/(auth)/mypage/MypageLayout';
+
+export default function MyProfilePage() {
+  const userContext = useUser();
+  const userData = userContext?.userData;
+
+  // 로딩 중 또는 데이터 없음
+  if (!userData) {
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <p className="text-gray-600">로딩 중...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1">
+      <div className="max-w-[640px]">
+        {/* 페이지 제목 */}
+        <div className="mb-8">
+          <h1 className="text-lg font-bold text-gray-900 mb-2">
+            내 정보
+          </h1>
+          <p className="text-sm text-gray-600">
+            내정보와 비밀번호를 수정하실 수 있습니다.
+          </p>
+        </div>
+
+        {/* 폼 영역 */}
+        <div className="space-y-6">
+          {/* 닉네임 영역 */}
+          <div>
+            <Input
+              label="닉네임"
+              type="text"
+              value={userData.nickname}
+              readOnly
+              className="bg-gray-50 cursor-default"
+              fullWidth
+            />
+          </div>
+
+          {/* 이메일 영역 */}
+          <div>
+            <Input
+              label="이메일"
+              type="email"
+              value={userData.email}
+              readOnly
+              className="bg-gray-50 cursor-default"
+              fullWidth
+            />
+          </div>
+
+          {/* 비밀번호 영역 */}
+          <div>
+            <Input
+              label="비밀번호"
+              type="password"
+              value="********"
+              readOnly
+              className="bg-gray-50 cursor-default"
+              fullWidth
+            />
+          </div>
+
+          {/* 비밀번호 확인 영역 */}
+          <div>
+            <Input
+              label="비밀번호 확인"
+              type="password"
+              value="********"
+              readOnly
+              className="bg-gray-50 cursor-default"
+              fullWidth
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -1,0 +1,42 @@
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'https://sp-globalnomad-api.vercel.app/19-7';
+
+// GET - 내 정보 조회
+export async function GET() {
+  try {
+    const cookieStore = await cookies();
+    const token = cookieStore.get('accessToken')?.value;
+
+    console.log('🟢 GET /api/users/me');
+    console.log('🟢 Token:', token ? '있음' : '없음');
+
+    if (!token) {
+      return NextResponse.json({ error: '인증 토큰이 없습니다.' }, { status: 401 });
+    }
+
+    const response = await fetch(`${BASE_URL}/users/me`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`,
+      },
+    });
+
+    console.log('🟢 External API Status:', response.status);
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      console.error('🟢 External API Error:', errorData);
+      return NextResponse.json({ error: '사용자 정보를 불러오는데 실패했습니다.' }, { status: response.status });
+    }
+
+    const data = await response.json();
+    console.log('🟢 Response Data:', data);
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('🔴 GET error:', error);
+    return NextResponse.json({ error: '서버 오류가 발생했습니다.' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## 📌 PR 개요

- 이 PR이 어떤 목적을 가지고 있는지 간단히 설명해주세요.

- 기존 172번 PR에서 있었던 멘토님이 말씀하신 기준으로 코드 분할 함. 
- 이거 머지 후 바로 다음 기능 정해주신 것에 맞게 해서 pr 새로 올릴 예정

## 🔍 관련 이슈

- Closes #179   
  (ex. Closes #12)

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [X] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [x] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [] ✅ test (테스트 코드)
- [x] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- src/apis/user.ts 파일에서 UserProfile 타입으로 불로온 사용자 정보 구조에 정의를 내림
- route.ts 파일에서 GET 핸들러가 쿠키에서 토큰을 꺼내고, API를 호출해서 사용자 정보를 반환함
- MypageLayout은 페이지 마운트시 getMyProfile()을 호출해서 사용자 정보 가져오기 및 UserContext를 이용하여 userData전달
- 마지막으로 페이지에서는 Context에서 userData를 받아오고, 일단 제 파일 기준으로는 수정 가능하여서 읽기 전용으로 표시 했습니다

## 📝 PR 제목 규칙

PR 제목은 커밋 컨벤션을 따라야 합니다.  
ex) feat: 롤링페이퍼 작성 기능 추가 (#15)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

- UI 변경이 있다면 캡처 이미지 첨부
<img width="1171" height="708" alt="스크린샷 2026-01-09 오전 3 03 10" src="https://github.com/user-attachments/assets/e0c52c69-c459-4047-a6dc-78cc53ffe537" />

## 🤝 기타 참고 사항

