### PR TITLE
feat: 내 체험 예약 현황 페이지 UI 구현(#191)

### DIFF
--- a/src/app/(auth)/mypage/reservation-status/page.tsx
+++ b/src/app/(auth)/mypage/reservation-status/page.tsx
@@ -1,3 +1,43 @@
+"use client";
+
+import { useState } from "react";
+import ReservationsDropdown from "@/src/components/Dropdown/ReservationsDropdown";
+import Calendar from "@/src/components/Calendar/Calendar";
+import { useReservationOptions } from "@/src/features/mypage/reservation-status/hooks/useReservationOptions";
+import { MOCK_SUMMARY } from "@/src/app/dev/donghyeon/page";
+
 export default function Page() {
-  return <div />;
+  const [selectedReservation, setSelectedReservation] = useState<
+    string | undefined
+  >(undefined);
+
+  const { items } = useReservationOptions();
+
+  return (
+    <section className="w-full flex justify-center">
+      {/* 가운데 컨텐츠 영역 */}
+      <div className="w-full max-w-[640px] flex flex-col gap-6">
+        {/* 상단 텍스트 */}
+        <div>
+          <h1 className="text-h4 font-bold">예약 현황</h1>
+          <p className="text-body text-gray-500">
+            내 체험에 예약된 내역을 한 눈에 확인할 수 있습니다.
+          </p>
+        </div>
+
+        {/* 체험 선택 드롭다운 */}
+        <div>
+          <ReservationsDropdown
+            items={items}
+            value={selectedReservation}
+            onChange={setSelectedReservation}
+          />
+        </div>
+
+        {/* 캘린더 */}
+
+        <Calendar summaryMap={MOCK_SUMMARY} />
+      </div>
+    </section>
+  );
 }

--- a/src/app/dev/donghyeon/page.tsx
+++ b/src/app/dev/donghyeon/page.tsx
@@ -2,7 +2,7 @@
 
 import Calendar, { DaySummary } from "@/src/components/Calendar/Calendar";
 
-const MOCK_SUMMARY: Record<string, DaySummary> = {
+export const MOCK_SUMMARY: Record<string, DaySummary> = {
   "2026-01-08": { completed: 10, reserved: 0, approved: 0 },
   "2026-01-10": { reserved: 2, approved: 0, completed: 0 },
   "2026-01-11": { reserved: 2, approved: 8, completed: 0 },
@@ -10,7 +10,7 @@ const MOCK_SUMMARY: Record<string, DaySummary> = {
 
 export default function CalendarTestPage() {
   return (
-    <div className="min-h-screen p-10">
+    <div className="max-w-[640px]">
       <Calendar summaryMap={MOCK_SUMMARY} />
     </div>
   );

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -74,7 +74,7 @@ export default function Calendar({ summaryMap = {} }: CalendarProps) {
   ];
 
   return (
-    <div className="rounded-2xl bg-white shadow-sm pt-6 pb-4">
+    <div className="rounded-2xl bg-white border border-gray-50 shadow-sm pt-5">
       {/* Header */}
       <div className="flex items-center justify-center gap-6 mb-4">
         <button onClick={() => setCurrentDate(subMonths(currentDate, 1))}>

--- a/src/features/mypage/reservation-status/hooks/mapReservationToDropdown.ts
+++ b/src/features/mypage/reservation-status/hooks/mapReservationToDropdown.ts
@@ -1,0 +1,12 @@
+import { Reservation } from "@/src/features/mypage/reservations/mocks/MockReservation";
+import { ReservationItem } from "@/src/components/Dropdown/ReservationsDropdown";
+
+export const mapReservationToDropdownItems = (
+  reservations: Reservation[]
+): ReservationItem[] => {
+  return reservations.map((r) => ({
+    label: r.activity.title,
+    value: String(r.id),
+    reservedAt: r.date,
+  }));
+};

--- a/src/features/mypage/reservation-status/hooks/useReservationOptions.ts
+++ b/src/features/mypage/reservation-status/hooks/useReservationOptions.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import { useMemo } from "react";
+import { ReservationItem } from "@/src/components/Dropdown/ReservationsDropdown";
+import { generateMockReservations } from "@/src/features/mypage/reservations/mocks/MockReservation";
+import { mapReservationToDropdownItems } from "./mapReservationToDropdown";
+
+export function useReservationOptions() {
+  const items: ReservationItem[] = useMemo(() => {
+    const reservations = generateMockReservations(20);
+    return mapReservationToDropdownItems(reservations);
+  }, []);
+
+  return { items };
+}


### PR DESCRIPTION
## 📌 PR 개요

- 내 체험 예약 현황 페이지 UI 구현

## 🔍 관련 이슈

- Closes #191 

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [x] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항


### 예약 현황 페이지
- 예약 현황 페이지에 체험 선택 드롭다운 + 캘린더 UI를 조합
- 드롭다운은 기존 공통 `ReservationsDropdown` 컴포넌트 사용
- 캘린더는 기존 `summaryMap` 인터페이스를 유지한 채 목데이터를 주입하여 테스트

### 목데이터 기반 데이터 흐름
- 예약 mock 데이터를 생성하는 `generateMockReservations` 활용
- 예약 데이터를 드롭다운 전용 데이터(`ReservationItem`)로 변환하는 util 추가
- 드롭다운 옵션 제공을 위한 `useReservationOptions` hook 추가



## 📝 PR 제목 규칙

feat: 내 체험 예약 현황 페이지 UI 구현(#191)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

<img width="1919" height="908" alt="image" src="https://github.com/user-attachments/assets/12f3bfe3-7b98-4f6e-8f1d-870f970c66a7" />


## 🤝 기타 참고 사항

- 현재는 목데이터를 사용하며, 추후 `/api/my-reservations` API 연동으로 교체 예정
