### PR TITLE
feat: 내 정보 페이지 (분할PR) 사이드 메뉴 이미지 변경 구현(#181)

### DIFF
--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -1,10 +1,16 @@
-export interface UserProfile {
+export interface UserProfile { // 로그인, 내 정도 등에서 사용되는 공통 타입 사용시 정보 받아오기 필요시 import 
   id: number;
   email: string;
   nickname: string;
   profileImageUrl: string | null;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface UpdateUserData {
+  nickname?: string;
+  profileImageUrl?: string;
+  newPassword?: string;
 }
 
 // GET - 내 정보 조회
@@ -15,6 +21,40 @@ export const getMyProfile = async (): Promise<UserProfile> => {
 
   if (!response.ok) {
     throw new Error('사용자 정보를 불러오는데 실패했습니다.');
+  }
+
+  return response.json();
+};
+
+// PATCH - 내 정보 수정
+export const updateMyProfile = async (data: UpdateUserData): Promise<UserProfile> => {
+  const response = await fetch('/api/users/me', {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+  });
+
+  if (!response.ok) {
+    throw new Error('정보 수정에 실패했습니다.');
+  }
+
+  return response.json();
+};
+
+// POST - 프로필 이미지 업로드
+export const uploadProfileImage = async (file: File): Promise<{ profileImageUrl: string }> => {
+  const formData = new FormData();
+  formData.append('image', file);
+
+  const response = await fetch('/api/users/me/image', {
+    method: 'POST',
+    body: formData,
+  });
+
+  if (!response.ok) {
+    throw new Error('이미지 업로드에 실패했습니다.');
   }
 
   return response.json();

--- a/src/app/(auth)/mypage/MypageLayout.tsx
+++ b/src/app/(auth)/mypage/MypageLayout.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, createContext, useContext } from 'react';
 import SideMenu from '@/src/components/SideMenu/SideMenu';
-import { getMyProfile, UserProfile } from '@/src/apis/user';
+import { getMyProfile, uploadProfileImage, updateMyProfile, UserProfile } from '@/src/apis/user';
 
 // 컨텍스트 정의
 interface UserContextType {
@@ -22,7 +22,28 @@ export const useUser = () => {
 
 // 내부 콘텐츠 컴포넌트
 function MyPageLayoutContent({ children }: { children: React.ReactNode }) {
-  const { userData } = useUser();
+  const { userData, refreshUser } = useUser();
+
+  const handleProfileEdit = () => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = 'image/*';
+    input.onchange = async (e) => {
+      const file = (e.target as HTMLInputElement).files?.[0];
+      if (!file) return;
+
+      try {
+        const uploadRes = await uploadProfileImage(file);
+        await updateMyProfile({ profileImageUrl: uploadRes.profileImageUrl });
+        await refreshUser();
+        alert('프로필 이미지가 변경되었습니다.');
+      } catch (error) {
+        console.error(error);
+        alert('이미지 변경에 실패했습니다.');
+      }
+    };
+    input.click();
+  };
 
   return (
     <main className="flex-1">
@@ -34,6 +55,7 @@ function MyPageLayoutContent({ children }: { children: React.ReactNode }) {
             <aside className="w-[260px] flex-shrink-0">
               <SideMenu
                 profileImageUrl={userData?.profileImageUrl}
+                onProfileEdit={handleProfileEdit}
               />
             </aside>
 
@@ -69,6 +91,10 @@ export default function MyPageLayout({ children }: MyPageLayoutProps) {
   const fetchUser = async () => {
     try {
       const data = await getMyProfile();
+      // 캐시 방지를 위한 타임스탬프 추가
+      if (data?.profileImageUrl) {
+        data.profileImageUrl = `${data.profileImageUrl}?v=${new Date().getTime()}`;
+      }
       setUserData(data);
     } catch (error) {
       console.error('사용자 정보 로드 실패:', error);

--- a/src/app/api/users/me/image/route.ts
+++ b/src/app/api/users/me/image/route.ts
@@ -1,0 +1,45 @@
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+// POST - 프로필 이미지 업로드
+export async function POST(request: Request) {
+  try {
+    const cookieStore = await cookies();
+    const token = cookieStore.get('accessToken')?.value;
+
+    if (!token) {
+      return NextResponse.json(
+        { error: '인증 토큰이 없습니다.' },
+        { status: 401 }
+      );
+    }
+
+    const formData = await request.formData();
+
+    const response = await fetch(`${BASE_URL}/users/me/image`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${token}`,
+      },
+      body: formData,
+    });
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: '이미지 업로드에 실패했습니다.' },
+        { status: response.status }
+      );
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('POST /api/users/me/image error:', error);
+    return NextResponse.json(
+      { error: '서버 오류가 발생했습니다.' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/users/me/image/route.ts
+++ b/src/app/api/users/me/image/route.ts
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 
-const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
 
 // POST - 프로필 이미지 업로드
 export async function POST(request: Request) {

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 
-const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
 
 // GET - 내 정보 조회
 export async function GET() {

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -1,16 +1,13 @@
 import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 
-const BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'https://sp-globalnomad-api.vercel.app/19-7';
+const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
 // GET - 내 정보 조회
 export async function GET() {
   try {
     const cookieStore = await cookies();
     const token = cookieStore.get('accessToken')?.value;
-
-    console.log('🟢 GET /api/users/me');
-    console.log('🟢 Token:', token ? '있음' : '없음');
 
     if (!token) {
       return NextResponse.json({ error: '인증 토큰이 없습니다.' }, { status: 401 });
@@ -24,19 +21,49 @@ export async function GET() {
       },
     });
 
-    console.log('🟢 External API Status:', response.status);
-
     if (!response.ok) {
       const errorData = await response.json();
-      console.error('🟢 External API Error:', errorData);
       return NextResponse.json({ error: '사용자 정보를 불러오는데 실패했습니다.' }, { status: response.status });
     }
 
     const data = await response.json();
-    console.log('🟢 Response Data:', data);
     return NextResponse.json(data);
   } catch (error) {
-    console.error('🔴 GET error:', error);
+    console.error('GET /api/users/me error:', error);
+    return NextResponse.json({ error: '서버 오류가 발생했습니다.' }, { status: 500 });
+  }
+}
+
+// PATCH - 내 정보 수정
+export async function PATCH(request: Request) {
+  try {
+    const cookieStore = await cookies();
+    const token = cookieStore.get('accessToken')?.value;
+
+    if (!token) {
+      return NextResponse.json({ error: '인증 토큰이 없습니다.' }, { status: 401 });
+    }
+
+    const body = await request.json();
+
+    const response = await fetch(`${BASE_URL}/users/me`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      return NextResponse.json({ error: '정보 수정에 실패했습니다.', details: errorData }, { status: response.status });
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('PATCH /api/users/me error:', error);
     return NextResponse.json({ error: '서버 오류가 발생했습니다.' }, { status: 500 });
   }
 }


### PR DESCRIPTION
## 📌 PR 개요

- 이 PR이 어떤 목적을 가지고 있는지 간단히 설명해주세요.
- 이전 1번(멘토님이 나눠주신 단위)에서 질문 받았던, 현재 MypageLayout에서 클라이언트로 되어있는 부분
팀원들이랑 서버에서 할지 클라이언트에서 할지 상의 한 번 해 보는게 어떠냐고 하셨는데, 토요일 팀 미팅시 늦게 일어나서 팀미팅 참여를 못 해서, 일단 서버 클라이언트 버전도 따로 파일을 만들어두고 일단 클라이언트 버전으로 업로드 합니다! 늦어도 월요일 팀미팅시 정해지면 3번부터는 정해진 방향으로 업로드 하도록 하겠습니다!!

## 🔍 관련 이슈

- Closes #181 
  (ex. Closes #12)

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [x] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [x] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- 주요 변경 내용을 리스트로 정리해주세요.
- 사이드 메뉴에서 이미지를 불러 오고, 변경시 유저 정보에 저장되도록 함.
- 이전 pr에서 얘기 해 주셨던 부분에서 현재 api/login/route.ts 파일에서 data.user를 사용하고 있는데, 
any타입을 사용중이라 그대로 받아 와도 사실상 작동은 하지만 타입스크립트를 쓰는 의미가 없을 것 같아 필요시 import 해서 공통으로 사용할 수 있도록 하는게 좋아 보여서 주석 추가를 했습니다! (일단 제 의견 입니다!)
- user.ts 파일에 이미지 업로드 (uploadProfileImage), 프로필 수정(updateMyProfile)추가 했습니다
- users/me/route.ts 파일에 이미지 url을 DB에 저장하기 위해서 패치 핸들러 추가 했습니다
- users/me/image/route.ts 파일에는 변경한 이미지 파일을 서버에 업로드하는 post 핸들러 추가 했습니다
- MypageLayout에는 프로필 이미지 클릭시 파일 선택하고, 업로드 시키는 handleProfileEdit 함수 추가 했습니다!
- route.ts 파일 두 개에 기존 키 값 같이 적혀 있던 거 제거하고 .env에 키 값 옮겨적던 중. BASE를 붙여 버린채 푸쉬 되어서 해당 파일 두 개 재 커밋했습니다


## 📝 PR 제목 규칙

PR 제목은 커밋 컨벤션을 따라야 합니다.  
ex) feat: 롤링페이퍼 작성 기능 추가 (#15)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

- UI 변경이 있다면 캡처 이미지 첨부

https://github.com/user-attachments/assets/17bc17a1-5ffa-41a2-bd28-6826512806e2



## 🤝 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 맥락(설계 의도, 제약사항 등)
