### PR TITLE
feat: 체험 상세 페이지 카카오맵 구현 (#193)

### DIFF
--- a/src/app/activities/[activityId]/page.tsx
+++ b/src/app/activities/[activityId]/page.tsx
@@ -1,3 +1,381 @@
-export default function Page() {
-  return <div />;
-}
+'use client';
+
+import React from 'react';
+import Reservation from '@/src/components/Reservation/Reservation';
+import { Pagination } from '@/src/components/Pagination/Pagination';
+import { ActivityData } from '@/src/types/activityType';
+import { Coordinates } from '@/src/types/kakaoMapType';
+import { Review } from '@/src/types/reviewType';
+import LocationIcon from '@/assets/icon_location.svg';
+import KebabMenuIcon from '@/assets/icon_kebab_menu.svg';
+import StarIcon from '@/assets/icon_star.svg';
+
+// 목업 데이터 (API 연동 전)
+const mockActivityData: ActivityData = {
+  category: "문화 · 예술",
+  title: "함께 배우면 즐거운 스트릿 댄스",
+  rating: 4.2,
+  reviewCount: 1300,
+  location: "서울 중구 명동8길 100 5F",
+  address: "서울 중구 명동8길 100 5F",
+  price: 1000,
+  description: `안녕하세요! 저는 스트릿 댄스 제윤을 가르치는데요. 처음으로 나 좋아하게 만든 댄스를 한 곳에서 배울 수 있어요. 처음 해보시는데 여기 와서 댄스는 한 곳에서 배울 수 있어요. 
+  
+시간이 흐를 수록 춤보다 사람을 만나고 그는 친구와 시간 보내기 좋아서 사람들 만나고 시작하고 저는 또 이해 와서 같은 시간 동안 춤을 그려서 저도 많은 걸 받아가려고 마치 초등학교 때처럼 이해와 오해, 배움과 재능, 그래도 이 수업은 인연만 만들면 다른 것은 제외하고 시작이에요. 
+  
+세부로 작은 여러분들을 실력만 쌓는 것이 아닌 마음을 채우고 사랑하는 시간이 되었으면 해요.`,
+  bannerImageUrl: null,
+  subImages: [],
+  availableTimes: ["14:00~15:00", "15:00~16:00", "16:00~17:00", "17:00~18:00"],
+  coordinates: { lat: 37.5665, lng: 126.9780 },
+  reviews: [
+    {
+      id: 1,
+      author: "김지현",
+      rating: 5,
+      date: "2022.2.4",
+      content: "처음 저는 스트릿 댄서 체험에 참가했을 때 진짜 만족했어요. 밝은 분위기 시설 덕분 중요해요."
+    },
+    {
+      id: 2,
+      author: "조현서",
+      rating: 5,
+      date: "2022.2.4",
+      content: "다음에 또 다시 가고 싶어요! 저도 춤실력 성장 조식되었어요."
+    },
+    {
+      id: 3,
+      author: "이서준",
+      rating: 4,
+      date: "2022.2.5",
+      content: "좋은 경험이었습니다. 강사님이 친절하셨어요."
+    },
+    {
+      id: 4,
+      author: "박민지",
+      rating: 5,
+      date: "2022.2.6",
+      content: "재미있게 배울 수 있어서 좋았습니다!"
+    },
+    {
+      id: 5,
+      author: "최예린",
+      rating: 4,
+      date: "2022.2.7",
+      content: "시설도 깨끗하고 분위기가 좋아요."
+    }
+  ]
+};
+
+const ActivityDetailPage = () => {
+  const activityData = mockActivityData;
+
+  return (
+    <div className="bg-white">
+      <div className="max-w-[1200px] mx-auto px-6 py-8">
+        <div className="grid grid-cols-1 lg:grid-cols-[1fr_350px] gap-8">
+          
+          <div className="space-y-8">
+            <ImageGallery 
+              bannerImage={activityData.bannerImageUrl}
+              images={activityData.subImages}
+            />
+            <DescriptionSection description={activityData.description} />
+            <LocationSection 
+              address={activityData.address}
+              coordinates={activityData.coordinates}
+            />
+            <ReviewSection 
+              rating={activityData.rating}
+              reviewCount={activityData.reviewCount}
+              reviews={activityData.reviews}
+            />
+          </div>
+          
+          <div className="space-y-4">
+            <div className="flex items-start justify-between">
+              <div className="flex-1">
+                <div className="text-body text-gray-600 mb-2">
+                  {activityData.category}
+                </div>
+                <h1 className="text-h4 font-bold text-gray-900 tracking-h4 mb-3">
+                  {activityData.title}
+                </h1>
+                <div className="flex items-center gap-2 text-body text-gray-600 mb-2">
+                  <Star filled={true} size="small" />
+                  <span className="font-medium">{activityData.rating}</span>
+                  <span>({activityData.reviewCount})</span>
+                </div>
+                <div className="flex items-center gap-1 text-body text-gray-600">
+                  <LocationIcon className="w-4 h-4" />
+                  <span>{activityData.location}</span>
+                </div>
+              </div>
+              <KebabMenu />
+            </div>
+            
+            <p className="text-body text-gray-700">
+              초보자부터 전문가까지 즐겁는 즐거움을 함께 느껴보세요.
+            </p>
+            
+            <ReservationCard 
+              pricePerPerson={activityData.price}
+              availableTimes={activityData.availableTimes}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// 케밥 메뉴
+const KebabMenu = () => {
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  const handleEdit = () => {
+    window.location.href = '/my-reservations/1';
+  };
+
+  const handleDelete = () => {
+    if (confirm('정말 삭제하시겠습니까?')) {
+      alert('삭제되었습니다.');
+    }
+  };
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="w-8 h-8 flex items-center justify-center text-gray-600 hover:bg-gray-100 rounded-full"
+      >
+        <KebabMenuIcon className="w-5 h-5" />
+      </button>
+
+      {isOpen && (
+        <>
+          <div 
+            className="fixed inset-0 z-10" 
+            onClick={() => setIsOpen(false)}
+          />
+          <div className="absolute right-0 mt-2 w-32 bg-white border border-gray-200 rounded-lg shadow-lg z-20">
+            <button
+              onClick={handleEdit}
+              className="w-full px-4 py-3 text-left text-body text-gray-900 hover:bg-gray-50 rounded-t-lg"
+            >
+              수정하기
+            </button>
+            <button
+              onClick={handleDelete}
+              className="w-full px-4 py-3 text-left text-body text-gray-900 hover:bg-gray-50 rounded-b-lg"
+            >
+              삭제하기
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+// 이미지
+const ImageGallery = ({ bannerImage, images }: { bannerImage: string | null; images: string[] }) => {
+  return (
+    <div className="space-y-4">
+      <div className="w-full aspect-[16/9] bg-gray-100 rounded-lg overflow-hidden">
+        {bannerImage ? (
+          <img 
+            src={bannerImage} 
+            alt="체험 메인 이미지" 
+            className="w-full h-full object-cover"
+          />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center text-gray-500">
+            체험 등록 이미지 표시 영역
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+// 체험 설명
+const DescriptionSection = ({ description }: { description: string }) => {
+  return (
+    <div className="space-y-4">
+      <h2 className="text-h3 font-bold text-gray-900 tracking-h3">
+        체험 설명
+      </h2>
+      <div className="p-6 bg-gray-25 rounded-lg">
+        <p className="text-body text-gray-600 text-center">
+          체험 등록 설명 연동 예정
+        </p>
+      </div>
+    </div>
+  );
+};
+
+// 오시는 길(카카오맵)
+const LocationSection = ({ address, coordinates }: { address: string; coordinates: Coordinates }) => {
+  const mapRef = React.useRef(null);
+
+  React.useEffect(() => {
+    const script = document.createElement('script');
+    script.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_MAP_API_KEY}&autoload=false`;
+    script.async = true;
+    document.head.appendChild(script);
+
+    script.onload = () => {
+      window.kakao.maps.load(() => {
+        const container = mapRef.current;
+        if (!container) return;
+        
+        const options = {
+          center: new window.kakao.maps.LatLng(coordinates.lat, coordinates.lng),
+          level: 3
+        };
+
+        const map = new window.kakao.maps.Map(container, options);
+
+        const markerPosition = new window.kakao.maps.LatLng(coordinates.lat, coordinates.lng);
+        const marker = new window.kakao.maps.Marker({
+          position: markerPosition
+        });
+        marker.setMap(map);
+      });
+    };
+
+    return () => {
+      document.head.removeChild(script);
+    };
+  }, [coordinates]);
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-h3 font-bold text-gray-900 tracking-h3">
+        오시는 길
+      </h2>
+      <p className="text-body text-gray-600">
+        {address}
+      </p>
+      <div 
+        ref={mapRef}
+        className="w-full h-[400px] bg-gray-100 rounded-lg overflow-hidden"
+      />
+    </div>
+  );
+};
+
+// 후기 섹션
+const ReviewSection = ({ rating, reviewCount, reviews }: { rating: number; reviewCount: number; reviews: Review[] }) => {
+  const [currentPage, setCurrentPage] = React.useState(1);
+  const reviewsPerPage = 3;
+  
+  const indexOfLastReview = currentPage * reviewsPerPage;
+  const indexOfFirstReview = indexOfLastReview - reviewsPerPage;
+  const currentReviews = reviews.slice(indexOfFirstReview, indexOfLastReview);
+  const totalPages = Math.ceil(reviews.length / reviewsPerPage);
+
+  return (
+    <div className="space-y-6">
+      {/* 후기 헤더 */}
+      <div className="flex items-center gap-2">
+        <h2 className="text-h3 font-bold text-gray-900 tracking-h3">
+          체험 후기
+        </h2>
+        <span className="text-body font-medium text-gray-600">{reviewCount}개</span>
+      </div>
+
+      {/* 평점 정보 */}
+      <div className="flex flex-col items-center justify-center py-6">
+        <div className="text-[32px] font-bold text-gray-900 leading-none mb-2">
+          {rating}
+        </div>
+        <div className="text-body-lg font-bold text-gray-900 mb-2">
+          매우 만족
+        </div>
+        <div className="flex items-center gap-1">
+          <div className="flex">
+            {[1, 2, 3, 4, 5].map((star) => (
+              <Star key={star} filled={star <= Math.round(rating)} size="small" />
+            ))}
+          </div>
+          <span className="text-body font-medium text-gray-600 ml-1">{reviewCount}개 후기</span>
+        </div>
+      </div>
+
+      {/* 리뷰 목록 */}
+      <div className="space-y-3">
+        {currentReviews.length > 0 ? (
+          currentReviews.map((review) => (
+            <div 
+              key={review.id} 
+              className="bg-white rounded-lg p-6"
+              style={{ boxShadow: '0px 4px 24px 0px rgba(156, 180, 202, 0.2)' }}
+            >
+              <div className="flex items-center gap-2 mb-2">
+                <span className="text-body-lg font-bold text-gray-900">{review.author}</span>
+                <span className="text-body text-gray-500">{review.date}</span>
+              </div>
+              <div className="flex mb-2">
+                {[1, 2, 3, 4, 5].map((star) => (
+                  <Star key={star} filled={star <= review.rating} size="small" />
+                ))}
+              </div>
+              <p className="text-body text-gray-700">{review.content}</p>
+            </div>
+          ))
+        ) : (
+          <div className="p-8 bg-gray-25 rounded-lg">
+            <p className="text-body text-gray-600 text-center">
+              아직 작성된 리뷰가 없습니다.
+            </p>
+          </div>
+        )}
+      </div>
+      
+      {/* Pagination */}
+      {reviews.length > 0 && totalPages > 1 && (
+        <div className="flex justify-center">
+          <Pagination 
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onPageChange={setCurrentPage}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+// 후기 별 아이콘 컴포넌트
+const Star = ({ filled, size = "normal" }: { filled: boolean; size?: string }) => {
+  const sizeClass = size === "small" ? "w-4 h-4" : "w-6 h-6";
+  const color = filled ? "#FFC107" : "#E0E0E5";
+  
+  return (
+    <StarIcon 
+      className={sizeClass}
+      style={{ color }}
+    />
+  );
+};
+
+// 예약 카드
+const ReservationCard = ({ pricePerPerson, availableTimes }: { pricePerPerson: number; availableTimes: string[] }) => {
+  return (
+    <div 
+      className="bg-white rounded-lg p-4" 
+      style={{ boxShadow: '0px 4px 24px 0px rgba(156, 180, 202, 0.2)' }}
+    >
+      <div className="[&>*]:!text-body [&_h3]:!text-body-lg [&_button]:!text-body [&_span]:!text-body [&>*]:!border-0">
+        <Reservation 
+          pricePerPerson={pricePerPerson}
+          availableTimes={availableTimes}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ActivityDetailPage;

--- a/src/assets/icon_kebab_menu.svg
+++ b/src/assets/icon_kebab_menu.svg
@@ -1,0 +1,5 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="10" cy="4" r="1.5"/>
+  <circle cx="10" cy="10" r="1.5"/>
+  <circle cx="10" cy="16" r="1.5"/>
+</svg>

--- a/src/assets/icon_location.svg
+++ b/src/assets/icon_location.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/Reservation/Reservation.tsx
+++ b/src/components/Reservation/Reservation.tsx
@@ -7,14 +7,16 @@ import Button from '@/src/components/Button/Button';
 
 const DAY_LIST = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
 
-const TIME_SLOTS = [
-  '14:00~15:00',
-  '15:00~16:00',
-  '16:00~17:00',
-  '17:00~18:00',
-];
+// Props 타입 정의 (API에서 받아올 데이터)
+interface ReservationProps {
+  pricePerPerson?: number; // 체험 등록 페이지에서 설정한 1인당 가격
+  availableTimes?: string[]; // 체험 등록 페이지에서 설정한 예약 가능 시간대
+}
 
-export default function Reservation() {
+export default function Reservation({ 
+  pricePerPerson = 1000, // 목업 (API 연동 전까지 사용)
+  availableTimes = ['14:00~15:00', '15:00~16:00', '16:00~17:00', '17:00~18:00'] // 기본값
+}: ReservationProps) {
   const {
     weeks,
     handlePrevMonth,
@@ -26,11 +28,10 @@ export default function Reservation() {
     getFormattedMonthYear,
   } = useReservation();
 
-  const [attendees, setAttendees] = useState(10);
-  const [selectedTime, setSelectedTime] = useState<string | null>('15:00~16:00');
+  const [attendees, setAttendees] = useState(1);
+  const [selectedTime, setSelectedTime] = useState<string | null>(availableTimes[0] || null);
   const [hasSelectedDate, setHasSelectedDate] = useState(false);
 
-  const pricePerPerson = 1000;
   const totalPrice = pricePerPerson * attendees;
 
   const handleIncreaseAttendees = () => setAttendees((prev) => prev + 1);
@@ -44,32 +45,32 @@ export default function Reservation() {
   };
 
   return (
-    <div className="w-full max-w-md bg-white rounded-3xl shadow-lg p-6">
+    <div className="w-full bg-white p-0">
       {/* 가격 */}
-      <div className="mb-6">
-        <span className="text-2xl font-bold text-gray-900">₩ {pricePerPerson.toLocaleString()}</span>
-        <span className="text-gray-600 ml-1">/ 인</span>
+      <div className="mb-4">
+        <span className="text-h2 font-bold text-gray-900 tracking-h2">₩ {pricePerPerson.toLocaleString()}</span>
+        <span className="text-gray-600 ml-1 text-h3 font-medium">/ 인</span>
       </div>
 
       {/* 날짜 섹션 */}
-      <div className="mb-6">
-        <h3 className="text-lg font-bold text-gray-900 mb-4">날짜</h3>
+      <div className="mb-4">
+        <h3 className="text-body-lg font-bold text-gray-900 mb-3">날짜</h3>
 
         {/* 월/년도 헤더 */}
-        <div className="flex justify-between items-center mb-4">
-          <span className="text-base font-semibold text-gray-900">
+        <div className="flex justify-between items-center mb-3">
+          <span className="text-body-lg font-medium text-gray-900">
             {getFormattedMonthYear()}
           </span>
-          <div className="flex gap-4">
+          <div className="flex gap-3">
             <button
               onClick={handlePrevMonth}
-              className="w-6 h-6 flex items-center justify-center text-gray-900 hover:text-gray-600"
+              className="w-5 h-5 flex items-center justify-center text-gray-900 hover:text-gray-600"
             >
               ◀
             </button>
             <button
               onClick={handleNextMonth}
-              className="w-6 h-6 flex items-center justify-center text-gray-900 hover:text-gray-600"
+              className="w-5 h-5 flex items-center justify-center text-gray-900 hover:text-gray-600"
             >
               ▶
             </button>
@@ -77,18 +78,18 @@ export default function Reservation() {
         </div>
 
         {/* 요일 헤더 */}
-        <div className="grid grid-cols-7 gap-2 mb-2">
+        <div className="grid grid-cols-7 gap-1 mb-2">
           {DAY_LIST.map((day, index) => (
-            <div key={index} className="text-center text-sm font-semibold text-gray-600">
+            <div key={index} className="text-center text-body-lg font-semibold text-gray-600">
               {day}
             </div>
           ))}
         </div>
 
         {/* 날짜 그리드 */}
-        <div className="space-y-2">
+        <div className="space-y-1">
           {weeks.map((week, weekIndex) => (
-            <div key={weekIndex} className="grid grid-cols-7 gap-2">
+            <div key={weekIndex} className="grid grid-cols-7 gap-1">
               {week.map((day, dayIndex) => {
                 const isTodayDate = isToday(day);
                 const isSelectedDate = hasSelectedDate && isSelected(day);
@@ -100,7 +101,7 @@ export default function Reservation() {
                     onClick={() => !isOtherMonth && handleDateSelect(day)}
                     disabled={isOtherMonth}
                     className={`
-                      aspect-square flex items-center justify-center rounded-full text-sm font-medium
+                      aspect-square flex items-center justify-center rounded-full text-body-lg font-bold
                       transition-colors
                       ${isOtherMonth ? 'text-gray-300 cursor-default' : 'text-gray-900 hover:bg-gray-50'}
                       ${isTodayDate && !isSelectedDate ? 'bg-primary-100 text-primary-500' : ''}
@@ -117,23 +118,23 @@ export default function Reservation() {
       </div>
 
       {/* 참여 인원수 */}
-      <div className="mb-6">
+      <div className="mb-4">
         <div className="flex justify-between items-center">
-          <h3 className="text-lg font-bold text-gray-900">참여 인원수</h3>
-          <div className="flex items-center gap-3 border border-gray-200 rounded-full px-5">
+          <h3 className="text-body-lg font-bold text-gray-900">참여 인원수</h3>
+          <div className="flex items-center gap-2 border border-gray-200 rounded-full px-4 py-1">
             <button
               onClick={handleDecreaseAttendees}
               disabled={attendees <= 1}
-              className="w-11 h-11 flex items-center justify-center bg-white text-gray-900 text-xl hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed"
+              className="w-8 h-8 flex items-center justify-center bg-white text-gray-900 text-body-lg font-bold hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed"
             >
               −
             </button>
-            <span className="text-lg font-semibold text-gray-900 min-w-[32px] text-center">
+            <span className="text-body-lg font-bold text-gray-900 min-w-[28px] text-center">
               {attendees}
             </span>
             <button
               onClick={handleIncreaseAttendees}
-              className="w-11 h-11 flex items-center justify-center bg-white text-gray-900 text-xl hover:bg-gray-50"
+              className="w-8 h-8 flex items-center justify-center bg-white text-gray-900 text-body-lg font-bold hover:bg-gray-50"
             >
               +
             </button>
@@ -142,15 +143,15 @@ export default function Reservation() {
       </div>
 
       {/* 예약 가능한 시간 */}
-      <div className="mb-6">
-        <h3 className="text-lg font-bold text-gray-900 mb-4">예약 가능한 시간</h3>
-        <div className="space-y-3">
-          {TIME_SLOTS.map((time) => (
+      <div className="mb-4">
+        <h3 className="text-body-lg font-bold text-gray-900 mb-3">예약 가능한 시간</h3>
+        <div className="space-y-2">
+          {availableTimes.map((time) => (
             <button
               key={time}
               onClick={() => setSelectedTime(time)}
               className={`
-                w-full h-14 rounded-xl border text-base font-semibold transition-colors
+                w-full h-12 rounded-lg border text-body-lg font-medium transition-colors
                 ${
                   selectedTime === time
                     ? 'bg-primary-100 border-primary-500 text-primary-500'
@@ -165,10 +166,10 @@ export default function Reservation() {
       </div>
 
       {/* 하단 예약하기 */}
-      <div className="flex justify-between items-center pt-4 border-t border-gray-200">
-        <div className="flex items-baseline gap-3">
-          <span className="text-sm text-gray-600">총 합계</span>
-          <span className="text-xl font-bold text-gray-900">
+      <div className="flex justify-between items-center pt-3 border-t border-gray-200">
+        <div className="flex items-baseline gap-2">
+          <span className="text-h3 font-medium text-gray-600">총 합계</span>
+          <span className="text-h3 font-bold text-gray-900 tracking-h3">
             ₩ {totalPrice.toLocaleString()}
           </span>
         </div>

--- a/src/types/activityType.ts
+++ b/src/types/activityType.ts
@@ -1,0 +1,19 @@
+import { Coordinates } from '@/src/types/kakaoMapType';
+import { Review } from '@/src/types/reviewType';
+
+// 체험 상세 데이터 타입
+export interface ActivityData {
+  category: string;
+  title: string;
+  rating: number;
+  reviewCount: number;
+  location: string;
+  address: string;
+  price: number;
+  description: string;
+  bannerImageUrl: string | null;
+  subImages: string[];
+  availableTimes: string[];
+  coordinates: Coordinates;
+  reviews: Review[];
+}

--- a/src/types/kakaoMapType.ts
+++ b/src/types/kakaoMapType.ts
@@ -1,0 +1,41 @@
+// 좌표 타입
+export interface Coordinates {
+  lat: number;
+  lng: number;
+}
+
+// 카카오맵 타입 정의
+export interface KakaoLatLng {
+  getLat(): number;
+  getLng(): number;
+}
+
+export interface KakaoMarker {
+  setMap(map: KakaoMap | null): void;
+}
+
+export interface KakaoMap {
+  setCenter(latlng: KakaoLatLng): void;
+  getLevel(): number;
+  setLevel(level: number): void;
+}
+
+export interface KakaoMaps {
+  LatLng: new (lat: number, lng: number) => KakaoLatLng;
+  Map: new (container: HTMLElement, options: { center: KakaoLatLng; level: number }) => KakaoMap;
+  Marker: new (options: { position: KakaoLatLng }) => KakaoMarker;
+  load(callback: () => void): void;
+}
+
+export interface Kakao {
+  maps: KakaoMaps;
+}
+
+// 카카오맵 전역 타입 선언
+declare global {
+  interface Window {
+    kakao: Kakao;
+  }
+}
+
+export {};

--- a/src/types/reviewType.ts
+++ b/src/types/reviewType.ts
@@ -1,0 +1,8 @@
+// 리뷰 타입
+export interface Review {
+  id: number;
+  author: string;
+  rating: number;
+  date: string;
+  content: string;
+}


### PR DESCRIPTION
## 📌 PR 개요

- 다른 api 연동 전 카카오맵 먼저 연동
- 말 그대로 다른 기능 없이 목업 데이터만 넣어놓은 임시 파일임

## 🔍 관련 이슈

- Closes #193 
  (ex. Closes #12)

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [x] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [x] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항


- 카카오맵 api를 연동했고, 체험 등록시 등록된 위치 좌표를 기준으로 지정된 영역 지도에 뜸.
- 테스트 위치는 서울 시청으로 잡음

`ex`

- 로그인 API 연동 (`/api/login`) 추가
- 로그인 폼에서 이메일/비밀번호 유효성 검사 로직 추가
- 로그인 성공 시 JWT 토큰을 localStorage에 저장하도록 수정
- UI: 로그인 버튼 클릭 시 로딩 스피너 추가

## 📝 PR 제목 규칙

PR 제목은 커밋 컨벤션을 따라야 합니다.  
ex) feat: 롤링페이퍼 작성 기능 추가 (#15)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

- UI 변경이 있다면 캡처 이미지 첨부
<img width="1016" height="716" alt="스크린샷 2026-01-13 오전 1 49 39" src="https://github.com/user-attachments/assets/e9a3a49d-faee-4464-b22f-a93da366a416" />

## 🤝 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 맥락(설계 의도, 제약사항 등)
- 원래 리저베이션 컴포넌트는 따로 올리려고 했으나, 타입 에러랑 빌드 에러가 발생해서 커밋만 따로 해서 올림
- 카카오맵 사용하기 위해서 NEXT_PUBLIC_KAKAO_MAP_API_KEY=53bbfc0c7bdd02c4fee2f9d5ddfd301a
이렇게 .env.local에 추가 해 주시면 됩니다. 그리고 추가로 배포하고 나서 링크 local말고, 카카오 디벨로퍼에서 웹 링크 수정 해야 합니다. 현재 api 받아오면서 로컬 호스트 주소로 잡아놔서 배포시 링크가 달라져 작동이 안 될 겁니다
