### PR TITLE
feat: 내 체험 예약 현황 구현(#195)

### DIFF
--- a/src/app/(auth)/mypage/reservation-status/page.tsx
+++ b/src/app/(auth)/mypage/reservation-status/page.tsx
@@ -1,17 +1,112 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import ReservationsDropdown from "@/src/components/Dropdown/ReservationsDropdown";
 import Calendar from "@/src/components/Calendar/Calendar";
+import ReservationPopover, {
+  TabKey,
+  TimeOption,
+} from "@/src/components/Popover/Popover";
+
 import { useReservationOptions } from "@/src/features/mypage/reservation-status/hooks/useReservationOptions";
-import { MOCK_SUMMARY } from "@/src/app/dev/donghyeon/page";
+import { useReservationDashboard } from "@/src/features/mypage/reservation-status/hooks/useReservationDashboard";
+import { useReservedSchedule } from "@/src/features/mypage/reservation-status/hooks/useReservationSchedule";
+import { useReservations } from "@/src/features/mypage/reservation-status/hooks/useReservations";
+
+import { ReservationStatus } from "@/src/features/mypage/reservation-status/type";
+
+interface PopoverInfo {
+  dateLabel: string;
+  anchorEl: HTMLElement;
+}
 
 export default function Page() {
-  const [selectedReservation, setSelectedReservation] = useState<
-    string | undefined
-  >(undefined);
+  const [selectedActivityId, setSelectedActivityId] = useState<number>();
+  const [popoverInfo, setPopoverInfo] = useState<PopoverInfo | null>(null);
+  const [activeTab, setActiveTab] = useState<TabKey>("requested");
+
+  const [userSelectedScheduleId, setUserSelectedScheduleId] = useState<
+    number | null
+  >(null);
+
+  const year = new Date().getFullYear();
+  const month = new Date().getMonth() + 1;
 
   const { items } = useReservationOptions();
+
+  const { summaryMap, refetch: refetchDashboard } = useReservationDashboard(
+    selectedActivityId,
+    year,
+    month
+  );
+
+  const {
+    schedules,
+    loading: scheduleLoading,
+    error: scheduleError,
+  } = useReservedSchedule(selectedActivityId, popoverInfo?.dateLabel);
+
+  const timeOptions: TimeOption[] = useMemo(() => {
+    return schedules.map((s) => ({
+      id: s.scheduleId,
+      startTime: s.startTime,
+      endTime: s.endTime,
+      fullTime: `${s.startTime} - ${s.endTime}`,
+    }));
+  }, [schedules]);
+
+  const selectedScheduleId = useMemo(() => {
+    if (userSelectedScheduleId !== null) return userSelectedScheduleId;
+    if (timeOptions.length === 0) return undefined;
+    return timeOptions[0].id;
+  }, [userSelectedScheduleId, timeOptions]);
+
+  const reservationStatus: ReservationStatus | undefined = useMemo(() => {
+    switch (activeTab) {
+      case "requested":
+        return "pending";
+      case "approved":
+        return "confirmed";
+      case "declined":
+        return "declined";
+      default:
+        return undefined;
+    }
+  }, [activeTab]);
+
+  const {
+    reservations,
+    loading: reservationsLoading,
+    error: reservationsError,
+    refetch,
+  } = useReservations({
+    activityId: selectedActivityId,
+    scheduleId: selectedScheduleId,
+    status: reservationStatus,
+  });
+
+  const updateReservationStatus = async (
+    reservationId: number,
+    status: ReservationStatus
+  ) => {
+    if (!selectedActivityId) return;
+
+    const res = await fetch(
+      `/api/my-activities/${selectedActivityId}/reservations/${reservationId}`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status }),
+      }
+    );
+
+    if (!res.ok) {
+      throw new Error(await res.text());
+    }
+
+    refetch();
+    refetchDashboard();
+  };
 
   return (
     <section className="w-full flex justify-center">
@@ -24,19 +119,52 @@ export default function Page() {
             내 체험에 예약된 내역을 한 눈에 확인할 수 있습니다.
           </p>
         </div>
-
         {/* 체험 선택 드롭다운 */}
         <div>
           <ReservationsDropdown
             items={items}
-            value={selectedReservation}
-            onChange={setSelectedReservation}
+            value={selectedActivityId?.toString()}
+            onChange={(value) => {
+              setSelectedActivityId(Number(value));
+              setPopoverInfo(null);
+              setUserSelectedScheduleId(null);
+            }}
           />
         </div>
 
         {/* 캘린더 */}
+        <Calendar
+          summaryMap={summaryMap}
+          onBadgeClick={({ dateKey, anchorEl }) => {
+            setPopoverInfo({ dateLabel: dateKey, anchorEl });
+            setActiveTab("requested");
+            setUserSelectedScheduleId(null);
+          }}
+        />
 
-        <Calendar summaryMap={MOCK_SUMMARY} />
+        {popoverInfo && selectedActivityId && (
+          <ReservationPopover
+            isOpen
+            onClose={() => setPopoverInfo(null)}
+            dateLabel={popoverInfo.dateLabel}
+            anchorEl={popoverInfo.anchorEl}
+            activeTab={activeTab}
+            onTabChange={setActiveTab}
+            timeOptions={timeOptions}
+            selectedTimeId={selectedScheduleId ?? 0}
+            onTimeChange={setUserSelectedScheduleId}
+            reservations={reservations}
+            loading={reservationsLoading}
+            onApprove={(id) => updateReservationStatus(id, "confirmed")}
+            onDecline={(id) => updateReservationStatus(id, "declined")}
+          />
+        )}
+
+        {(scheduleError || reservationsError) && (
+          <p className="text-red-500 text-center">
+            {scheduleError || reservationsError}
+          </p>
+        )}
       </div>
     </section>
   );

--- a/src/app/api/my-activities/[activityId]/reservation-dashboard/route.ts
+++ b/src/app/api/my-activities/[activityId]/reservation-dashboard/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+export async function GET(
+  req: NextRequest,
+  context: { params: Promise<{ activityId: string }> }
+) {
+  const { activityId } = await context.params;
+
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get("accessToken")?.value;
+
+  if (!accessToken) {
+    return NextResponse.json(
+      { message: "로그인이 필요합니다." },
+      { status: 401 }
+    );
+  }
+
+  const searchParams = new URL(req.url).searchParams;
+  const year = searchParams.get("year");
+  const month = searchParams.get("month");
+
+  if (!year || !month) {
+    return NextResponse.json(
+      { message: "year와 month는 필수입니다." },
+      { status: 400 }
+    );
+  }
+
+  const backendUrl =
+    `${process.env.NEXT_PUBLIC_API_URL}` +
+    `/my-activities/${activityId}/reservation-dashboard` +
+    `?year=${year}&month=${month}`;
+
+  const res = await fetch(backendUrl, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/src/app/api/my-activities/[activityId]/reservations/[reservationId]/route.ts
+++ b/src/app/api/my-activities/[activityId]/reservations/[reservationId]/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+export async function PATCH(
+  req: NextRequest,
+  {
+    params,
+  }: {
+    params: Promise<{
+      activityId: string;
+      reservationId: string;
+    }>;
+  }
+) {
+  const { activityId, reservationId } = await params;
+
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get("accessToken")?.value;
+
+  if (!accessToken) {
+    return NextResponse.json(
+      { message: "로그인이 필요합니다." },
+      { status: 401 }
+    );
+  }
+
+  let body: { status?: "confirmed" | "declined" };
+
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json(
+      { message: "요청 본문이 올바르지 않습니다." },
+      { status: 400 }
+    );
+  }
+
+  if (!body.status || !["confirmed", "declined"].includes(body.status)) {
+    return NextResponse.json(
+      { message: "허용되지 않은 status 값입니다." },
+      { status: 400 }
+    );
+  }
+
+  const backendUrl =
+    `${process.env.NEXT_PUBLIC_API_URL}` +
+    `/my-activities/${activityId}/reservations/${reservationId}`;
+
+  const res = await fetch(backendUrl, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({ status: body.status }),
+  });
+
+  if (!res.ok) {
+    const error = await res.json().catch(() => ({
+      message: "예약 상태 변경에 실패했습니다.",
+    }));
+    return NextResponse.json(error, { status: res.status });
+  }
+
+  const data = await res.json().catch(() => null);
+  return NextResponse.json(data, { status: res.status });
+}

--- a/src/app/api/my-activities/[activityId]/reservations/route.ts
+++ b/src/app/api/my-activities/[activityId]/reservations/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+const ALLOWED_STATUS = ["pending", "confirmed", "declined"] as const;
+type AllowedStatus = (typeof ALLOWED_STATUS)[number];
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ activityId: string }> }
+) {
+  const { activityId } = await params;
+
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get("accessToken")?.value;
+
+  if (!accessToken) {
+    return NextResponse.json(
+      { message: "로그인이 필요합니다." },
+      { status: 401 }
+    );
+  }
+
+  const { searchParams } = new URL(req.url);
+
+  const scheduleIdParam = searchParams.get("scheduleId");
+  const statusParam = searchParams.get("status");
+
+  if (!scheduleIdParam) {
+    return NextResponse.json(
+      { message: "scheduleId는 필수입니다." },
+      { status: 400 }
+    );
+  }
+
+  const scheduleId = Number(scheduleIdParam);
+  if (Number.isNaN(scheduleId)) {
+    return NextResponse.json(
+      { message: "scheduleId는 숫자로 입력해주세요." },
+      { status: 400 }
+    );
+  }
+
+  if (!statusParam) {
+    return NextResponse.json(
+      { message: "status는 필수입니다." },
+      { status: 400 }
+    );
+  }
+
+  const normalizedStatus = statusParam.trim().toLowerCase();
+
+  const isValidStatus = (value: string): value is AllowedStatus => {
+    return ALLOWED_STATUS.includes(value as AllowedStatus);
+  };
+
+  if (!isValidStatus(normalizedStatus)) {
+    return NextResponse.json(
+      {
+        message:
+          "status는 pending, confirmed, declined 중 하나로 입력해주세요.",
+      },
+      { status: 400 }
+    );
+  }
+
+  const backendUrl =
+    `${process.env.NEXT_PUBLIC_API_URL}` +
+    `/my-activities/${activityId}/reservations` +
+    `?scheduleId=${scheduleId}&status=${normalizedStatus}`;
+
+  const res = await fetch(backendUrl, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/src/app/api/my-activities/[activityId]/reserved-schedule/route.ts
+++ b/src/app/api/my-activities/[activityId]/reserved-schedule/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+export async function GET(
+  req: NextRequest,
+  context: { params: Promise<{ activityId: string }> }
+) {
+  const { activityId } = await context.params;
+
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get("accessToken")?.value;
+
+  if (!accessToken) {
+    return NextResponse.json(
+      { message: "로그인이 필요합니다." },
+      { status: 401 }
+    );
+  }
+
+  const searchParams = new URL(req.url).searchParams;
+  const date = searchParams.get("date");
+
+  if (!date) {
+    return NextResponse.json(
+      { message: "date는 필수입니다." },
+      { status: 400 }
+    );
+  }
+
+  const backendUrl =
+    `${process.env.NEXT_PUBLIC_API_URL}` +
+    `/my-activities/${activityId}/reserved-schedule?date=${date}`;
+
+  const res = await fetch(backendUrl, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/src/app/api/my-activities/route.ts
+++ b/src/app/api/my-activities/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+export async function GET(req: NextRequest) {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get("accessToken")?.value;
+
+  if (!accessToken) {
+    return NextResponse.json(
+      { message: "로그인이 필요합니다." },
+      { status: 401 }
+    );
+  }
+
+  const { searchParams } = new URL(req.url);
+  const cursorId = searchParams.get("cursorId");
+  const size = searchParams.get("size") ?? "20";
+
+  const backendUrl = new URL(
+    `${process.env.NEXT_PUBLIC_API_URL}/my-activities`
+  );
+
+  if (cursorId) backendUrl.searchParams.set("cursorId", cursorId);
+  backendUrl.searchParams.set("size", size);
+
+  const res = await fetch(backendUrl.toString(), {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/src/app/dev/junyeol/page.tsx
+++ b/src/app/dev/junyeol/page.tsx
@@ -1,72 +1,75 @@
-'use client'
+"use client";
 
-import { useState, useRef } from 'react';
+import { useState, useRef } from "react";
 import SideMenu from "@/src/components/SideMenu/SideMenu";
-import UserMenuDropDown from '@/src/components/Dropdown/UserMenuDropDown';
-import PriceSortDropdown, { PriceSortValue } from '@/src/components/Dropdown/PriceSortDropdown';
-import ActivitiesCategoryDropdown, { ActivityCategory } from '@/src/components/Dropdown/ActivitiesCategoryDropdown';
-import ReservationsDropdown, { ReservationItem } from '@/src/components/Dropdown/ReservationsDropdown';
-import { CalendarDayCell } from '@/src/components/Calendar/CalendarDayCell';
-import { EventBadge } from '@/src/components/Calendar/EventBadge';
-import { Pagination } from '@/src/components/Pagination/Pagination';
+import UserMenuDropDown from "@/src/components/Dropdown/UserMenuDropDown";
+import PriceSortDropdown, {
+  PriceSortValue,
+} from "@/src/components/Dropdown/PriceSortDropdown";
+import ActivitiesCategoryDropdown, {
+  ActivityCategory,
+} from "@/src/components/Dropdown/ActivitiesCategoryDropdown";
+import ReservationsDropdown, {
+  ReservationItem,
+} from "@/src/components/Dropdown/ReservationsDropdown";
+import { CalendarDayCell } from "@/src/components/Calendar/CalendarDayCell";
+import { EventBadge } from "@/src/components/Calendar/EventBadge";
+import { Pagination } from "@/src/components/Pagination/Pagination";
 import Search from "@/src/components/Search/Search";
-import ReservationsTimeDropdown from '@/src/components/Dropdown/ReservationsTimeDropdown';
-import Popover from '@/src/components/Popover/Popover'
-import Button from '@/src/components/Button/Button';
-import Input from '@/src/components/Input/Input';
-
+import ReservationsTimeDropdown from "@/src/components/Dropdown/ReservationsTimeDropdown";
+import Popover from "@/src/components/Popover/Popover";
+import Button from "@/src/components/Button/Button";
+import Input from "@/src/components/Input/Input";
 
 // api 연동 전 목업 데이터
 const MOCK_RESERVATIONS: ReservationItem[] = [
   {
-    label: '서핑 입문 체험',
-    value: '1',
-    reservedAt: '2024-12-01',
+    label: "서핑 입문 체험",
+    value: "1",
+    reservedAt: "2024-12-01",
   },
   {
-    label: '도자기 원데이 클래스',
-    value: '2',
-    reservedAt: '2025-01-03',
+    label: "도자기 원데이 클래스",
+    value: "2",
+    reservedAt: "2025-01-03",
   },
   {
-    label: '함께 배우는 즐거운 스트릿댄스',
-    value: '3',
-    reservedAt: '2025-02-10',
+    label: "함께 배우는 즐거운 스트릿댄스",
+    value: "3",
+    reservedAt: "2025-02-10",
   },
 ];
 
 const MOCK_TIMES = [
-  { id: 1, startTime: '14:00', endTime: '15:00' },
-  { id: 2, startTime: '15:00', endTime: '16:00' },
-  { id: 3, startTime: '16:00', endTime: '17:00' },
-]
+  { id: 1, startTime: "14:00", endTime: "15:00" },
+  { id: 2, startTime: "15:00", endTime: "16:00" },
+  { id: 3, startTime: "16:00", endTime: "17:00" },
+];
 
 // ReservationsDropdown 최근 예약 기준 정렬
 const sortedReservations = [...MOCK_RESERVATIONS].sort(
-  (a, b) =>
-    new Date(b.reservedAt).getTime() -
-    new Date(a.reservedAt).getTime()
+  (a, b) => new Date(b.reservedAt).getTime() - new Date(a.reservedAt).getTime()
 );
 
 export default function JunyeolPage() {
-  const [sort, setSort] = useState<PriceSortValue>('price_asc');
+  const [sort, setSort] = useState<PriceSortValue>("price_asc");
   const [category, setCategory] = useState<ActivityCategory | undefined>();
   const [reservation, setReservation] = useState<string | undefined>(
     sortedReservations[0]?.value
   );
   const [selectedTimeId, setSelectedTimeId] = useState<number>(
     MOCK_TIMES[0].id
-  )
+  );
   const [currentPage, setCurrentPage] = useState(1);
   const TOTAL_PAGES = 12;
-  const [searchValue, setSearchValue] = useState('');
+  const [searchValue, setSearchValue] = useState("");
 
   const handleSearch = (value: string) => {
-    console.log('검색어:', value);
-  }
+    console.log("검색어:", value);
+  };
 
-  const anchorRef = useRef<HTMLButtonElement>(null)
-  const [open, setOpen] = useState(false)
+  const anchorRef = useRef<HTMLButtonElement>(null);
+  const [open, setOpen] = useState(false);
 
   return (
     <div className="flex flex-col gap-10 justify-center items-center">
@@ -76,7 +79,7 @@ export default function JunyeolPage() {
         {/* api 연동시 로그아웃 로직 구현 */}
         <UserMenuDropDown
           userName="김준열"
-          onLogout={() => alert('로그아웃')}
+          onLogout={() => alert("로그아웃")}
           className="w-25"
         />
 
@@ -112,21 +115,20 @@ export default function JunyeolPage() {
       </div>
 
       <div className="flex flex-col gap-10 justify-center items-center">
-        <h2 className="text-h2">ReservationsTimeDropDown 컴포넌트를 사용하는 Popover 컴포넌트 테스트</h2>
+        <h2 className="text-h2">
+          ReservationsTimeDropDown 컴포넌트를 사용하는 Popover 컴포넌트 테스트
+        </h2>
         <div className="flex flex-col border border-primary-100 rounded-xl p-10 gap-10 justify-center items-center">
-          <Button
-            ref={anchorRef}
-            onClick={() => setOpen(true)}
-          >
+          <Button ref={anchorRef} onClick={() => setOpen(true)}>
             테스트
           </Button>
 
-          <Popover
+          {/* <Popover
             isOpen={open}
             onClose={() => setOpen(false)}
             dateLabel="2024-01-09"
-            anchorRef={anchorRef}
-          />
+            // anchorRef={anchorRef}
+          /> */}
         </div>
       </div>
 
@@ -215,7 +217,8 @@ export default function JunyeolPage() {
           profileImageUrl={null}
           onProfileEdit={() => {
             console.log("프로필 편집");
-          }} />
+          }}
+        />
       </div>
 
       <h2 className="text-h2">Search 컴포넌트</h2>
@@ -236,7 +239,6 @@ export default function JunyeolPage() {
         <Input label="Password" type="password" placeholder="••••••••" />
         <Input label="Error" error="에러" />
       </div>
-
     </div>
   );
 }

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -10,6 +10,7 @@ import {
 } from "date-fns";
 import { useState } from "react";
 import { CalendarDayCell } from "./CalendarDayCell";
+import { EventStatus } from "./EventBadge";
 
 export interface DaySummary {
   reserved: number;
@@ -25,9 +26,17 @@ const EMPTY_SUMMARY: DaySummary = {
 
 interface CalendarProps {
   summaryMap?: Record<string, DaySummary>;
+  onBadgeClick?: (payload: {
+    dateKey: string;
+    status: EventStatus;
+    anchorEl: HTMLElement;
+  }) => void;
 }
 
-export default function Calendar({ summaryMap = {} }: CalendarProps) {
+export default function Calendar({
+  summaryMap = {},
+  onBadgeClick,
+}: CalendarProps) {
   const [currentDate, setCurrentDate] = useState(() => new Date());
 
   const year = currentDate.getFullYear();
@@ -59,7 +68,7 @@ export default function Calendar({ summaryMap = {} }: CalendarProps) {
     ...prevDays.map((day) => ({
       day,
       isOutsideMonth: true,
-      dateKey: null,
+      dateKey: null as string | null,
     })),
     ...currentDays.map((day) => ({
       day,
@@ -69,7 +78,7 @@ export default function Calendar({ summaryMap = {} }: CalendarProps) {
     ...nextDays.map((day) => ({
       day,
       isOutsideMonth: true,
-      dateKey: null,
+      dateKey: null as string | null,
     })),
   ];
 
@@ -107,6 +116,15 @@ export default function Calendar({ summaryMap = {} }: CalendarProps) {
               summary={
                 dateKey ? (summaryMap[dateKey] ?? EMPTY_SUMMARY) : EMPTY_SUMMARY
               }
+              onBadgeClick={(payload) => {
+                if (!dateKey || !onBadgeClick) return;
+
+                onBadgeClick({
+                  dateKey,
+                  status: payload.status,
+                  anchorEl: payload.anchorEl,
+                });
+              }}
             />
           </div>
         ))}

--- a/src/components/Calendar/CalendarDayCell.tsx
+++ b/src/components/Calendar/CalendarDayCell.tsx
@@ -11,7 +11,10 @@ interface CalendarDayCellProps {
   summary: DaySummary;
   className?: string;
   isOutsideMonth?: boolean;
-  onBadgeClick?: (status: EventStatus) => void;
+  onBadgeClick?: (payload: {
+    status: EventStatus;
+    anchorEl: HTMLElement;
+  }) => void;
 }
 
 const TRACKING_FIELDS: (keyof DaySummary)[] = [
@@ -33,9 +36,9 @@ export const CalendarDayCell = ({
   return (
     <div
       className={`flex flex-col gap-[5px] 
-                        px-3 pt-[18px] pb-[10px] 
-                        bg-white  
-                        ${className}`}
+        px-3 pt-[18px] pb-[10px] 
+        bg-white  
+        ${className}`}
     >
       {/* 날짜 + 뱃지가 있을 시 알림 빨간 점 */}
       <div className="relative flex items-center justify-center">
@@ -58,7 +61,12 @@ export const CalendarDayCell = ({
         <EventBadge
           status="RESERVED"
           count={summary.reserved}
-          onClick={() => onBadgeClick?.("RESERVED")}
+          onClick={(e) =>
+            onBadgeClick?.({
+              status: "RESERVED",
+              anchorEl: e.currentTarget,
+            })
+          }
         />
       )}
 
@@ -66,7 +74,12 @@ export const CalendarDayCell = ({
         <EventBadge
           status="APPROVED"
           count={summary.approved}
-          onClick={() => onBadgeClick?.("APPROVED")}
+          onClick={(e) =>
+            onBadgeClick?.({
+              status: "APPROVED",
+              anchorEl: e.currentTarget,
+            })
+          }
         />
       )}
 
@@ -74,7 +87,12 @@ export const CalendarDayCell = ({
         <EventBadge
           status="COMPLETED"
           count={summary.completed}
-          onClick={() => onBadgeClick?.("COMPLETED")}
+          onClick={(e) =>
+            onBadgeClick?.({
+              status: "COMPLETED",
+              anchorEl: e.currentTarget,
+            })
+          }
         />
       )}
     </div>

--- a/src/components/Calendar/EventBadge.tsx
+++ b/src/components/Calendar/EventBadge.tsx
@@ -3,7 +3,7 @@ export type EventStatus = "RESERVED" | "APPROVED" | "COMPLETED";
 interface EventBadgeProps {
   status: EventStatus;
   count: number;
-  onClick?: () => void;
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
 const BADGE_STYLE = {

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -1,41 +1,35 @@
 "use client";
 
-import { RefObject, useEffect, useRef, useState, useMemo } from "react";
+import { useMemo, useRef } from "react";
 import StatusBadge from "@/src/components/Card/StatusBadge";
 import DeleteIcon from "@/src/assets/icon_delete.svg";
 import ReservationsTimeDropdown from "@/src/components/Dropdown/ReservationsTimeDropdown";
+import { Reservation } from "@/src/features/mypage/reservation-status/type";
 
-type TabKey = "requested" | "approved" | "declined";
+export type TabKey = "requested" | "approved" | "declined";
 
-interface Reservation {
+export interface TimeOption {
   id: number;
-  name: string;
-  people: number;
-  time: string;
-  status?: "pending" | "declined";
+  startTime: string;
+  endTime: string;
+  fullTime: string;
 }
 
 interface ReservationPopoverProps {
   isOpen: boolean;
   onClose: () => void;
   dateLabel: string;
-  anchorRef: RefObject<HTMLElement | null>;
+  anchorEl: HTMLElement;
+  activeTab: TabKey;
+  onTabChange: (tab: TabKey) => void;
+  timeOptions: TimeOption[];
+  selectedTimeId: number;
+  onTimeChange: (scheduleId: number) => void;
+  reservations: Reservation[];
+  loading?: boolean;
+  onApprove: (id: number) => void;
+  onDecline: (id: number) => void;
 }
-
-const INITIAL_RESERVATIONS: Reservation[] = [
-  {
-    id: 1,
-    name: "정만철",
-    people: 10,
-    time: "14:00 - 15:00",
-  },
-  {
-    id: 2,
-    name: "정만철",
-    people: 12,
-    time: "14:00 - 15:00",
-  },
-];
 
 const TAB_LABEL: Record<TabKey, string> = {
   requested: "신청",
@@ -47,92 +41,48 @@ export default function ReservationPopover({
   isOpen,
   onClose,
   dateLabel,
-  anchorRef,
+  anchorEl,
+  activeTab,
+  onTabChange,
+  timeOptions,
+  selectedTimeId,
+  onTimeChange,
+  reservations,
+  loading = false,
+  onApprove,
+  onDecline,
 }: ReservationPopoverProps) {
   const popoverRef = useRef<HTMLDivElement>(null);
-  const [style, setStyle] = useState<React.CSSProperties>({});
 
-  const [activeTab, setActiveTab] = useState<TabKey>("requested");
-  const [reservations, setReservations] =
-    useState<Reservation[]>(INITIAL_RESERVATIONS);
-
-  const timeOptions = useMemo(() => {
-  const timeStrings = Array.from(
-    new Set(reservations.map((r) => r.time))
-  )
-
-  return timeStrings.map((time, index) => {
-    const [startTime, endTime] = time.split('-').map(t => t.trim())
-
+  /* ======================
+   * 위치 계산
+   ====================== */
+  const style = useMemo<React.CSSProperties>(() => {
+    if (!isOpen || !anchorEl) return {};
+    const rect = anchorEl.getBoundingClientRect();
     return {
-      id: index,  // api 붙이면 수정
-      startTime,
-      endTime,
-      fullTime: time,
-    }
-  })
-}, [reservations])
-
-const [selectedTimeId, setSelectedTimeId] = useState<number>(() => {
-  return timeOptions[0]?.id ?? 0
-})
-
-const selectedTime = useMemo(() => {
-  return timeOptions.find(o => o.id === selectedTimeId)?.fullTime ?? ''
-}, [timeOptions, selectedTimeId])
-
-  useEffect(() => {
-    if (!isOpen || !anchorRef.current) return;
-
-    const rect = anchorRef.current.getBoundingClientRect();
-    setStyle({
       position: "fixed",
       top: rect.top,
       left: rect.right + 8,
       zIndex: 50,
-    });
-  }, [isOpen, anchorRef]);
-
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const handleClickOutside = (e: MouseEvent) => {
-      if (
-        popoverRef.current &&
-        !popoverRef.current.contains(e.target as Node) &&
-        !anchorRef.current?.contains(e.target as Node)
-      ) {
-        onClose();
-      }
     };
+  }, [isOpen, anchorEl]);
 
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [isOpen, onClose, anchorRef]);
+  /* ======================
+   * 예약 목록 필터링 
+   ====================== */
+  const filtered = useMemo(() => {
+    return reservations.filter((r) => {
+      if (selectedTimeId && r.scheduleId !== selectedTimeId) return false;
+
+      if (activeTab === "requested") return r.status === "pending";
+      if (activeTab === "approved") return r.status === "confirmed";
+      if (activeTab === "declined") return r.status === "declined";
+      return false;
+    });
+  }, [reservations, selectedTimeId, activeTab]);
 
   if (!isOpen) return null;
-
-  const approve = (id: number) => {
-    setReservations((prev) =>
-      prev.map((r) => (r.id === id ? { ...r, status: "pending" } : r))
-    );
-    setActiveTab("approved");
-  };
-
-  const decline = (id: number) => {
-    setReservations((prev) =>
-      prev.map((r) => (r.id === id ? { ...r, status: "declined" } : r))
-    );
-    setActiveTab("declined");
-  };
-
-  const filtered = reservations.filter((r) => {
-    if (r.time !== selectedTime) return false;
-
-    if (activeTab === "requested") return r.status === undefined;
-    if (activeTab === "approved") return r.status === "pending";
-    if (activeTab === "declined") return r.status === "declined";
-  });
 
   return (
     <aside
@@ -158,11 +108,12 @@ const selectedTime = useMemo(() => {
           {(Object.keys(TAB_LABEL) as TabKey[]).map((tab) => (
             <button
               key={tab}
-              onClick={() => setActiveTab(tab)}
-              className={`pb-2 ${activeTab === tab
-                ? "border-b-2 border-primary-500 text-primary-500 font-semibold"
-                : "text-gray-400"
-                }`}
+              onClick={() => onTabChange(tab)}
+              className={`pb-2 ${
+                activeTab === tab
+                  ? "border-b-2 border-primary-500 text-primary-500 font-semibold"
+                  : "text-gray-400"
+              }`}
             >
               {TAB_LABEL[tab]}
             </button>
@@ -175,54 +126,58 @@ const selectedTime = useMemo(() => {
           <ReservationsTimeDropdown
             times={timeOptions}
             value={selectedTimeId}
-            onChange={setSelectedTimeId}
+            onChange={onTimeChange}
           />
         </section>
 
         {/* 예약 내역 */}
         <section className="flex flex-col gap-3">
           <h3 className="text-m font-bold mb-2">예약 내역</h3>
-          {filtered.length === 0 && (
+
+          {loading && <p className="text-sm text-gray-400">불러오는 중…</p>}
+
+          {!loading && filtered.length === 0 && (
             <p className="text-sm text-gray-400">예약 내역이 없습니다.</p>
           )}
 
-          {filtered.map((r) => (
-            <div
-              key={r.id}
-              className="flex justify-between items-center border border-gray-100 rounded-xl p-3"
-            >
-              <div>
-                <p className="text-sm">
-                  <span className="text-gray-500 font-bold">닉네임 </span>
-                  <span className="text-black">{r.name}</span>
-                </p>
-                <p className="text-sm">
-                  <span className="text-gray-500 font-bold">인원 </span>
-                  <span className="text-black">{r.people}명</span>
-                </p>
-              </div>
-
-              {activeTab === "requested" ? (
-                <div className="flex flex-col text-sm gap-1">
-                  <button
-                    onClick={() => approve(r.id)}
-                    className="px-3 py-1 rounded-full bg-white border border-gray-50 text-gray-600 text-xs font-semibold"
-                  >
-                    승인하기
-                  </button>
-
-                  <button
-                    onClick={() => decline(r.id)}
-                    className=" px-3 py-1 rounded-full bg-gray-50 text-gray-600 text-xs font-semibold"
-                  >
-                    거절하기
-                  </button>
+          {!loading &&
+            filtered.map((r) => (
+              <div
+                key={r.id}
+                className="flex justify-between items-center border border-gray-100 rounded-xl p-3"
+              >
+                <div>
+                  <p className="text-sm">
+                    <span className="text-gray-500 font-bold">닉네임 </span>
+                    <span className="text-black">{r.nickname}</span>
+                  </p>
+                  <p className="text-sm">
+                    <span className="text-gray-500 font-bold">인원 </span>
+                    <span className="text-black">{r.headCount}명</span>
+                  </p>
                 </div>
-              ) : (
-                <StatusBadge status={r.status!} />
-              )}
-            </div>
-          ))}
+
+                {activeTab === "requested" ? (
+                  <div className="flex flex-col text-sm gap-1">
+                    <button
+                      onClick={() => onApprove(r.id)}
+                      className="px-3 py-1 rounded-full bg-white border border-gray-50 text-gray-600 text-xs font-semibold"
+                    >
+                      승인하기
+                    </button>
+
+                    <button
+                      onClick={() => onDecline(r.id)}
+                      className="px-3 py-1 rounded-full bg-gray-50 text-gray-600 text-xs font-semibold"
+                    >
+                      거절하기
+                    </button>
+                  </div>
+                ) : (
+                  <StatusBadge status={r.status} />
+                )}
+              </div>
+            ))}
         </section>
       </div>
     </aside>

--- a/src/features/mypage/reservation-status/hooks/useReservationDashboard.ts
+++ b/src/features/mypage/reservation-status/hooks/useReservationDashboard.ts
@@ -1,0 +1,73 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { authFetch } from "@/src/lib/api/authFetch";
+import {
+  ReservationDashboardApi,
+  CalendarDaySummary,
+} from "@/src/features/mypage/reservation-status/type";
+
+export function useReservationDashboard(
+  activityId?: number,
+  year?: number,
+  month?: number
+) {
+  const [summaryMap, setSummaryMap] = useState<
+    Record<string, CalendarDaySummary>
+  >({});
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchDashboard = useCallback(async () => {
+    if (!activityId || !year || !month) {
+      setSummaryMap({});
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await authFetch(
+        `/api/my-activities/${activityId}/reservation-dashboard?year=${year}&month=${String(
+          month
+        ).padStart(2, "0")}`
+      );
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => null);
+        throw new Error(err?.message || "예약 현황 조회 실패");
+      }
+
+      const data: ReservationDashboardApi[] = await res.json();
+
+      const mapped: Record<string, CalendarDaySummary> = {};
+
+      data.forEach((item) => {
+        mapped[item.date] = {
+          reserved: item.reservations.pending,
+          approved: item.reservations.confirmed,
+          completed: item.reservations.completed,
+        };
+      });
+
+      setSummaryMap(mapped);
+    } catch (e) {
+      setSummaryMap({});
+      setError(e instanceof Error ? e.message : "알 수 없는 오류");
+    } finally {
+      setLoading(false);
+    }
+  }, [activityId, year, month]);
+
+  useEffect(() => {
+    fetchDashboard();
+  }, [fetchDashboard]);
+
+  return {
+    summaryMap,
+    loading,
+    error,
+    refetch: fetchDashboard,
+  };
+}

--- a/src/features/mypage/reservation-status/hooks/useReservationOptions.ts
+++ b/src/features/mypage/reservation-status/hooks/useReservationOptions.ts
@@ -1,15 +1,55 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useState } from "react";
+import { authFetch } from "@/src/lib/api/authFetch";
 import { ReservationItem } from "@/src/components/Dropdown/ReservationsDropdown";
-import { generateMockReservations } from "@/src/features/mypage/reservations/mocks/MockReservation";
-import { mapReservationToDropdownItems } from "./mapReservationToDropdown";
+
+interface MyActivity {
+  id: number;
+  title: string;
+  createdAt: string;
+}
+
+interface MyActivitiesResponse {
+  activities: MyActivity[];
+}
 
 export function useReservationOptions() {
-  const items: ReservationItem[] = useMemo(() => {
-    const reservations = generateMockReservations(20);
-    return mapReservationToDropdownItems(reservations);
+  const [items, setItems] = useState<ReservationItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchActivities = async () => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const res = await authFetch("/api/my-activities");
+
+        if (!res.ok) {
+          throw new Error("체험 목록 조회 실패");
+        }
+
+        const data: MyActivitiesResponse = await res.json();
+
+        setItems(
+          data.activities.map((activity) => ({
+            value: String(activity.id),
+            label: activity.title,
+            reservedAt: activity.createdAt,
+          }))
+        );
+      } catch (e) {
+        setItems([]);
+        setError(e instanceof Error ? e.message : "알 수 없는 오류");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchActivities();
   }, []);
 
-  return { items };
+  return { items, loading, error };
 }

--- a/src/features/mypage/reservation-status/hooks/useReservationSchedule.ts
+++ b/src/features/mypage/reservation-status/hooks/useReservationSchedule.ts
@@ -1,0 +1,71 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { authFetch } from "@/src/lib/api/authFetch";
+
+export interface ReservedSchedule {
+  scheduleId: number;
+  startTime: string;
+  endTime: string;
+  count: {
+    pending: number;
+    confirmed: number;
+    declined: number;
+  };
+}
+
+export interface UseReservedScheduleResult {
+  schedules: ReservedSchedule[];
+  loading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+export function useReservedSchedule(
+  activityId?: number,
+  date?: string
+): UseReservedScheduleResult {
+  const [schedules, setSchedules] = useState<ReservedSchedule[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchSchedules = useCallback(async () => {
+    if (!activityId || !date) {
+      setSchedules([]);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await authFetch(
+        `/api/my-activities/${activityId}/reserved-schedule?date=${date}`
+      );
+
+      if (!res.ok) {
+        const errorData = await res.json().catch(() => null);
+        throw new Error(errorData?.message || "예약 스케줄 조회 실패");
+      }
+
+      const data: ReservedSchedule[] = await res.json();
+      setSchedules(data);
+    } catch (err) {
+      setSchedules([]);
+      setError(err instanceof Error ? err.message : "알 수 없는 에러");
+    } finally {
+      setLoading(false);
+    }
+  }, [activityId, date]);
+
+  useEffect(() => {
+    fetchSchedules();
+  }, [fetchSchedules]);
+
+  return {
+    schedules,
+    loading,
+    error,
+    refetch: fetchSchedules,
+  };
+}

--- a/src/features/mypage/reservation-status/hooks/useReservations.ts
+++ b/src/features/mypage/reservation-status/hooks/useReservations.ts
@@ -1,0 +1,76 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { authFetch } from "@/src/lib/api/authFetch";
+import {
+  Reservation,
+  ReservationStatus,
+} from "@/src/features/mypage/reservation-status/type";
+
+interface UseReservationsResult {
+  reservations: Reservation[];
+  loading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+interface UseReservationsParams {
+  activityId?: number;
+  scheduleId?: number;
+  status?: ReservationStatus;
+}
+
+export function useReservations({
+  activityId,
+  scheduleId,
+  status,
+}: UseReservationsParams): UseReservationsResult {
+  const [reservations, setReservations] = useState<Reservation[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchReservations = useCallback(async () => {
+    if (!activityId || !scheduleId || !status) {
+      setReservations([]);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const params = new URLSearchParams();
+      params.append("scheduleId", String(scheduleId));
+      params.append("status", status);
+
+      const res = await authFetch(
+        `/api/my-activities/${activityId}/reservations?${params.toString()}`
+      );
+
+      if (!res.ok) {
+        const errorData = await res.json().catch(() => null);
+        throw new Error(errorData?.message || "예약자 목록 조회 실패");
+      }
+
+      const data = await res.json();
+
+      setReservations(data.reservations ?? []);
+    } catch (e) {
+      setReservations([]);
+      setError(e instanceof Error ? e.message : "알 수 없는 오류");
+    } finally {
+      setLoading(false);
+    }
+  }, [activityId, scheduleId, status]);
+
+  useEffect(() => {
+    fetchReservations();
+  }, [fetchReservations]);
+
+  return {
+    reservations,
+    loading,
+    error,
+    refetch: fetchReservations,
+  };
+}

--- a/src/features/mypage/reservation-status/hooks/useUpdateReservationStatus.ts
+++ b/src/features/mypage/reservation-status/hooks/useUpdateReservationStatus.ts
@@ -1,0 +1,30 @@
+"use client";
+
+export function useUpdateReservationStatus() {
+  const updateStatus = async (
+    activityId: number,
+    reservationId: number,
+    status: "pending" | "confirmed" | "declined"
+  ) => {
+    const res = await fetch(
+      `/api/my-activities/${activityId}/reservations/${reservationId}`,
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        credentials: "include",
+        body: JSON.stringify({ status }),
+      }
+    );
+
+    if (!res.ok) {
+      const error = await res.json().catch(() => null);
+      throw new Error(error?.message ?? "예약 상태 변경 실패");
+    }
+
+    return res.json();
+  };
+
+  return { updateStatus };
+}

--- a/src/features/mypage/reservation-status/type.ts
+++ b/src/features/mypage/reservation-status/type.ts
@@ -1,0 +1,89 @@
+/* ======================
+ * 공통 예약 상태 
+ ====================== */
+export type ReservationStatus = "pending" | "confirmed" | "declined";
+
+/* ======================
+ * GET /my-activities/{activityId}/reservations
+ ====================== */
+export interface ReservationApi {
+  id: number;
+  nickname: string;
+  userId: number;
+  teamId: string;
+  activityId: number;
+  scheduleId: number;
+  status: ReservationStatus;
+  reviewSubmitted: boolean;
+  totalPrice: number;
+  headCount: number;
+  date: string;
+  startTime: string;
+  endTime: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/* ======================
+ *  예약자 리스트 응답
+ ====================== */
+export interface ReservationsResponse {
+  cursorId: number | null;
+  totalCount: number;
+  reservations: ReservationApi[];
+}
+
+/* ======================
+ * GET /reserved-schedule
+ ====================== */
+export interface ReservedScheduleApi {
+  scheduleId: number;
+  startTime: string;
+  endTime: string;
+  count: {
+    pending: number;
+    confirmed: number;
+    declined: number;
+  };
+}
+
+/* ======================
+ * GET /reservation-dashboard
+ ====================== */
+export interface ReservationDashboardApi {
+  date: string;
+  reservations: {
+    pending: number;
+    confirmed: number;
+    completed: number;
+  };
+}
+/* ======================
+ * 팝오버에서 쓰는 예약자
+ ====================== */
+export interface Reservation {
+  id: number;
+  nickname: string;
+  headCount: number;
+  status: "pending" | "confirmed" | "declined";
+  scheduleId: number;
+  startTime: string;
+  endTime: string;
+}
+
+/* ======================
+ * 캘린더 하루 요약
+ ====================== */
+export interface CalendarDaySummary {
+  reserved: number;
+  approved: number;
+  completed: number;
+}
+
+/* ======================
+ * 날짜 + scheduleId 메타
+ ====================== */
+export interface DayScheduleMeta {
+  date: string;
+  scheduleId: number;
+}


### PR DESCRIPTION
## 📌 PR 개요

- 내 체험 예약 현황 페이지 구현

## 🔍 관련 이슈

- Closes #195 


## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [x] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

훅 설명
- `useReservationOptions`
    - 로그인 한 사용자의 체험 목록 조회
    - 예약 현황 페이지 드롭다운에 바로 사용 가능하도록 드롭다운 아이템 형태로 변환
    - `GET /api/my-activities` API 사용
- `useReservationDashboard`
    - 선택한 체험의 월별 예약 요약 데이터 조회
    - 캘린더의 이벤트 뱃지에 렌더링
    - `GET /api/my-activities/{activityId}/reservation-dashboar' API 사용
    - API 응답인 pending / confirmed / completed를 UI에 맞게 reserved / approved / completed로 변환
    - 날짜별 요약 맵 형태로 제공
- `useReservedSchedule`
    - 선택한 날짜의 예약 시간대 리스트 조회
    - 시간대 별 예약 수 정보 제공
    - `GET /api/my-activities/{activityId}/reserved-schedule?date=` API 사용
    - 날짜 변경 시 자동 갱신, 팝오버 내 시간 선택 드롭다운에 사용
- `useReservations`
    - 특정 체험 / 날짜 / 시간대 / 상태에 해당하는 예약자 목록 조회
    - `GET /api/my-activities/{activityId}/reservations` API 사용
    - scheduleId과 status 기반 필터링
    - 팝오버 내 예야가 리스트에 사용
- `useUpdateReservationStatus`
    - 예약 승인 / 거절 상태 변경을 위하여 사용
    - `PATCH /api/my-activities/{activityId}/reservations/{reservationId}` API 사용
    - 상태 변경 후 예약자 리스트 재조회
    - 서버 상태를 기준으로 UI 갱신
라우트 설명

내 체험 목록 조회 라우트
- /api/my-activities

월별 예약 현황 조회 라우트
-  /api/my-activities/[activityId]/reservation-dashboard

날짜별 예약 스케줄 조회 라우트
-  /api/my-activities/[activityId]/reserved-schedule

예약자 목록 조회 라우트
- /api/my-activities/[activityId]/reservations

예약 승인 / 거절 상태 변경 라우트
-  /api/my-activities/[activityId]/reservations/[reservationId]

컴포넌트 수정

 Calendar, CalendarDayCell, EventBadge
- onClick 이벤트를 외부로 전달 가능하도록 확장

Popover
- 캘린더에서 클릭 된 뱃지 기준으로 해당 위치에 렌더링 되도록 수정
- 예약 시간대 선택 드롭다운 컴포넌트로 분리
- 상태 및 액션 처리는 외부에서 제어 가능하도록 정리

- 로그인 API 연동 (`/api/login`) 추가
- 로그인 폼에서 이메일/비밀번호 유효성 검사 로직 추가
- 로그인 성공 시 JWT 토큰을 localStorage에 저장하도록 수정
- UI: 로그인 버튼 클릭 시 로딩 스피너 추가


## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

<img width="1911" height="908" alt="스크린샷 2026-01-13 232648" src="https://github.com/user-attachments/assets/c85b370a-3c40-4bc1-9c70-2e437862bc49" />
<img width="1911" height="912" alt="스크린샷 2026-01-13 232700" src="https://github.com/user-attachments/assets/e9b14c1c-2c12-4654-b629-d31d8b56255a" />
<img width="1916" height="911" alt="스크린샷 2026-01-13 232711" src="https://github.com/user-attachments/assets/5d7b6938-246a-446f-9979-b284e0a2793a" />
<img width="1919" height="908" alt="스크린샷 2026-01-13 232723" src="https://github.com/user-attachments/assets/8da05f61-383b-4d04-b8d3-19176a516e7e" />


## 🤝 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 맥락(설계 의도, 제약사항 등)
