### PR TITLE
feat:체험 상세 페이지 조회 api 연동 및 카카오맵 주소=> 좌표 변동 적용 (임시) (#201)

### DIFF
--- a/src/app/activities/[activityId]/page.tsx
+++ b/src/app/activities/[activityId]/page.tsx
@@ -1,97 +1,92 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import Image from 'next/image';
 import Reservation from '@/src/components/Reservation/Reservation';
 import { Pagination } from '@/src/components/Pagination/Pagination';
 import { ActivityData } from '@/src/types/activityType';
-import { Coordinates } from '@/src/types/kakaoMapType';
 import { Review } from '@/src/types/reviewType';
-import LocationIcon from '@/assets/icon_location.svg';
-import KebabMenuIcon from '@/assets/icon_kebab_menu.svg';
-import StarIcon from '@/assets/icon_star.svg';
-
-// 목업 데이터 (API 연동 전)
-const mockActivityData: ActivityData = {
-  category: "문화 · 예술",
-  title: "함께 배우면 즐거운 스트릿 댄스",
-  rating: 4.2,
-  reviewCount: 1300,
-  location: "서울 중구 명동8길 100 5F",
-  address: "서울 중구 명동8길 100 5F",
-  price: 1000,
-  description: `안녕하세요! 저는 스트릿 댄스 제윤을 가르치는데요. 처음으로 나 좋아하게 만든 댄스를 한 곳에서 배울 수 있어요. 처음 해보시는데 여기 와서 댄스는 한 곳에서 배울 수 있어요. 
-  
-시간이 흐를 수록 춤보다 사람을 만나고 그는 친구와 시간 보내기 좋아서 사람들 만나고 시작하고 저는 또 이해 와서 같은 시간 동안 춤을 그려서 저도 많은 걸 받아가려고 마치 초등학교 때처럼 이해와 오해, 배움과 재능, 그래도 이 수업은 인연만 만들면 다른 것은 제외하고 시작이에요. 
-  
-세부로 작은 여러분들을 실력만 쌓는 것이 아닌 마음을 채우고 사랑하는 시간이 되었으면 해요.`,
-  bannerImageUrl: null,
-  subImages: [],
-  availableTimes: ["14:00~15:00", "15:00~16:00", "16:00~17:00", "17:00~18:00"],
-  coordinates: { lat: 37.5665, lng: 126.9780 },
-  reviews: [
-    {
-      id: 1,
-      author: "김지현",
-      rating: 5,
-      date: "2022.2.4",
-      content: "처음 저는 스트릿 댄서 체험에 참가했을 때 진짜 만족했어요. 밝은 분위기 시설 덕분 중요해요."
-    },
-    {
-      id: 2,
-      author: "조현서",
-      rating: 5,
-      date: "2022.2.4",
-      content: "다음에 또 다시 가고 싶어요! 저도 춤실력 성장 조식되었어요."
-    },
-    {
-      id: 3,
-      author: "이서준",
-      rating: 4,
-      date: "2022.2.5",
-      content: "좋은 경험이었습니다. 강사님이 친절하셨어요."
-    },
-    {
-      id: 4,
-      author: "박민지",
-      rating: 5,
-      date: "2022.2.6",
-      content: "재미있게 배울 수 있어서 좋았습니다!"
-    },
-    {
-      id: 5,
-      author: "최예린",
-      rating: 4,
-      date: "2022.2.7",
-      content: "시설도 깨끗하고 분위기가 좋아요."
-    }
-  ]
-};
+import { getActivityDetail } from '@/src/features/public/services/activities';
+import LocationIcon from '@/src/assets/icon_location.svg';
+import KebabMenuIcon from '@/src/assets/icon_kebab_menu.svg';
+import StarIcon from '@/src/assets/icon_star.svg';
 
 const ActivityDetailPage = () => {
-  const activityData = mockActivityData;
+  const params = useParams();
+  const activityId = params.activityId as string;
+  
+  const [activityData, setActivityData] = useState<ActivityData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // 임시 데이터 (API에 없는 필드)
+  const defaultReviews: Review[] = [];
+
+  useEffect(() => {
+    const fetchActivityData = async () => {
+      try {
+        setIsLoading(true);
+        const data = await getActivityDetail(activityId);
+        setActivityData(data);
+      } catch (err) {
+        console.error('API 에러:', err);
+        setError(err instanceof Error ? err.message : '데이터를 불러오는데 실패했습니다.');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchActivityData();
+  }, [activityId]);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <p className="text-body text-gray-600">로딩 중...</p>
+      </div>
+    );
+  }
+
+  if (error || !activityData) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <p className="text-body text-red-600">{error || '데이터를 불러올 수 없습니다.'}</p>
+      </div>
+    );
+  }
+
+  // availableTimes 변환 (첫 번째 스케줄의 시간대만 사용)
+  const availableTimes = activityData.schedules?.[0]?.times?.map(
+    time => `${time.startTime}~${time.endTime}`
+  ) || [];
+
+  // subImages URL 배열로 변환
+  const subImageUrls = activityData.subImages?.map(img => img.imageUrl) || [];
 
   return (
     <div className="bg-white">
       <div className="max-w-[1200px] mx-auto px-6 py-8">
         <div className="grid grid-cols-1 lg:grid-cols-[1fr_350px] gap-8">
           
+          {/* 왼쪽: 이미지 및 상세 정보 */}
           <div className="space-y-8">
             <ImageGallery 
               bannerImage={activityData.bannerImageUrl}
-              images={activityData.subImages}
+              images={subImageUrls}
             />
             <DescriptionSection description={activityData.description} />
             <LocationSection 
               address={activityData.address}
-              coordinates={activityData.coordinates}
             />
             <ReviewSection 
               rating={activityData.rating}
               reviewCount={activityData.reviewCount}
-              reviews={activityData.reviews}
+              reviews={defaultReviews}
             />
           </div>
           
+          {/* 오른쪽: 헤더 + 예약 카드 */}
           <div className="space-y-4">
             <div className="flex items-start justify-between">
               <div className="flex-1">
@@ -108,19 +103,19 @@ const ActivityDetailPage = () => {
                 </div>
                 <div className="flex items-center gap-1 text-body text-gray-600">
                   <LocationIcon className="w-4 h-4" />
-                  <span>{activityData.location}</span>
+                  <span>{activityData.address}</span>
                 </div>
               </div>
               <KebabMenu />
             </div>
             
             <p className="text-body text-gray-700">
-              초보자부터 전문가까지 즐겁는 즐거움을 함께 느껴보세요.
+              초보자부터 전문가까지 즐거운 체험을 함께 느껴보세요.
             </p>
             
             <ReservationCard 
               pricePerPerson={activityData.price}
-              availableTimes={activityData.availableTimes}
+              availableTimes={availableTimes}
             />
           </div>
         </div>
@@ -178,16 +173,18 @@ const KebabMenu = () => {
   );
 };
 
-// 이미지
+// 이미지 갤러리
 const ImageGallery = ({ bannerImage, images }: { bannerImage: string | null; images: string[] }) => {
   return (
     <div className="space-y-4">
-      <div className="w-full aspect-[16/9] bg-gray-100 rounded-lg overflow-hidden">
+      <div className="w-full aspect-[16/9] bg-gray-100 rounded-lg overflow-hidden relative">
         {bannerImage ? (
-          <img 
+          <Image 
             src={bannerImage} 
             alt="체험 메인 이미지" 
-            className="w-full h-full object-cover"
+            fill
+            className="object-cover"
+            priority
           />
         ) : (
           <div className="w-full h-full flex items-center justify-center text-gray-500">
@@ -195,6 +192,22 @@ const ImageGallery = ({ bannerImage, images }: { bannerImage: string | null; ima
           </div>
         )}
       </div>
+      
+      {/* 서브 이미지 */}
+      {images.length > 0 && (
+        <div className="grid grid-cols-4 gap-2">
+          {images.map((image, index) => (
+            <div key={index} className="aspect-square bg-gray-100 rounded-lg overflow-hidden relative">
+              <Image 
+                src={image} 
+                alt={`서브 이미지 ${index + 1}`} 
+                fill
+                className="object-cover"
+              />
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 };
@@ -207,21 +220,21 @@ const DescriptionSection = ({ description }: { description: string }) => {
         체험 설명
       </h2>
       <div className="p-6 bg-gray-25 rounded-lg">
-        <p className="text-body text-gray-600 text-center">
-          체험 등록 설명 연동 예정
+        <p className="text-body text-gray-700 whitespace-pre-wrap">
+          {description}
         </p>
       </div>
     </div>
   );
 };
 
-// 오시는 길(카카오맵)
-const LocationSection = ({ address, coordinates }: { address: string; coordinates: Coordinates }) => {
-  const mapRef = React.useRef(null);
+// 오시는 길
+const LocationSection = ({ address }: { address: string }) => {
+  const mapRef = React.useRef<HTMLDivElement>(null);
 
   React.useEffect(() => {
     const script = document.createElement('script');
-    script.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_MAP_API_KEY}&autoload=false`;
+    script.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_MAP_API_KEY}&autoload=false&libraries=services`;
     script.async = true;
     document.head.appendChild(script);
 
@@ -229,26 +242,52 @@ const LocationSection = ({ address, coordinates }: { address: string; coordinate
       window.kakao.maps.load(() => {
         const container = mapRef.current;
         if (!container) return;
-        
-        const options = {
-          center: new window.kakao.maps.LatLng(coordinates.lat, coordinates.lng),
-          level: 3
-        };
 
-        const map = new window.kakao.maps.Map(container, options);
+        // Geocoder 생성
+        const geocoder = new window.kakao.maps.services.Geocoder();
 
-        const markerPosition = new window.kakao.maps.LatLng(coordinates.lat, coordinates.lng);
-        const marker = new window.kakao.maps.Marker({
-          position: markerPosition
+        // 주소로 좌표 검색
+        geocoder.addressSearch(address, (result: Array<{ x: string; y: string }>, status: string) => {
+          if (status === window.kakao.maps.services.Status.OK) {
+            const coords = new window.kakao.maps.LatLng(
+              parseFloat(result[0].y), 
+              parseFloat(result[0].x)
+            );
+
+            const options = {
+              center: coords,
+              level: 3
+            };
+
+            const map = new window.kakao.maps.Map(container, options);
+
+            const marker = new window.kakao.maps.Marker({
+              position: coords
+            });
+            marker.setMap(map);
+          } else {
+            // 주소 검색 실패 시 기본 위치 (서울시청)
+            const defaultCoords = new window.kakao.maps.LatLng(37.5665, 126.9780);
+            const options = {
+              center: defaultCoords,
+              level: 3
+            };
+
+            const map = new window.kakao.maps.Map(container, options);
+
+            const marker = new window.kakao.maps.Marker({
+              position: defaultCoords
+            });
+            marker.setMap(map);
+          }
         });
-        marker.setMap(map);
       });
     };
 
     return () => {
       document.head.removeChild(script);
     };
-  }, [coordinates]);
+  }, [address]);
 
   return (
     <div className="space-y-4">
@@ -287,68 +326,78 @@ const ReviewSection = ({ rating, reviewCount, reviews }: { rating: number; revie
       </div>
 
       {/* 평점 정보 */}
-      <div className="flex flex-col items-center justify-center py-6">
-        <div className="text-[32px] font-bold text-gray-900 leading-none mb-2">
-          {rating}
-        </div>
-        <div className="text-body-lg font-bold text-gray-900 mb-2">
-          매우 만족
-        </div>
-        <div className="flex items-center gap-1">
-          <div className="flex">
-            {[1, 2, 3, 4, 5].map((star) => (
-              <Star key={star} filled={star <= Math.round(rating)} size="small" />
-            ))}
-          </div>
-          <span className="text-body font-medium text-gray-600 ml-1">{reviewCount}개 후기</span>
-        </div>
-      </div>
-
-      {/* 리뷰 목록 */}
-      <div className="space-y-3">
-        {currentReviews.length > 0 ? (
-          currentReviews.map((review) => (
-            <div 
-              key={review.id} 
-              className="bg-white rounded-lg p-6"
-              style={{ boxShadow: '0px 4px 24px 0px rgba(156, 180, 202, 0.2)' }}
-            >
-              <div className="flex items-center gap-2 mb-2">
-                <span className="text-body-lg font-bold text-gray-900">{review.author}</span>
-                <span className="text-body text-gray-500">{review.date}</span>
-              </div>
-              <div className="flex mb-2">
+      {reviewCount > 0 ? (
+        <>
+          <div className="flex flex-col items-center justify-center py-6">
+            <div className="text-[32px] font-bold text-gray-900 leading-none mb-2">
+              {rating}
+            </div>
+            <div className="text-body-lg font-bold text-gray-900 mb-2">
+              매우 만족
+            </div>
+            <div className="flex items-center gap-1">
+              <div className="flex">
                 {[1, 2, 3, 4, 5].map((star) => (
-                  <Star key={star} filled={star <= review.rating} size="small" />
+                  <Star key={star} filled={star <= Math.round(rating)} size="small" />
                 ))}
               </div>
-              <p className="text-body text-gray-700">{review.content}</p>
+              <span className="text-body font-medium text-gray-600 ml-1">{reviewCount}개 후기</span>
             </div>
-          ))
-        ) : (
-          <div className="p-8 bg-gray-25 rounded-lg">
-            <p className="text-body text-gray-600 text-center">
-              아직 작성된 리뷰가 없습니다.
-            </p>
           </div>
-        )}
-      </div>
-      
-      {/* Pagination */}
-      {reviews.length > 0 && totalPages > 1 && (
-        <div className="flex justify-center">
-          <Pagination 
-            currentPage={currentPage}
-            totalPages={totalPages}
-            onPageChange={setCurrentPage}
-          />
+
+          {/* 리뷰 목록 */}
+          <div className="space-y-3">
+            {currentReviews.length > 0 ? (
+              currentReviews.map((review) => (
+                <div 
+                  key={review.id} 
+                  className="bg-white rounded-lg p-6"
+                  style={{ boxShadow: '0px 4px 24px 0px rgba(156, 180, 202, 0.2)' }}
+                >
+                  <div className="flex items-center gap-2 mb-2">
+                    <span className="text-body-lg font-bold text-gray-900">{review.author}</span>
+                    <span className="text-body text-gray-500">{review.date}</span>
+                  </div>
+                  <div className="flex mb-2">
+                    {[1, 2, 3, 4, 5].map((star) => (
+                      <Star key={star} filled={star <= review.rating} size="small" />
+                    ))}
+                  </div>
+                  <p className="text-body text-gray-700">{review.content}</p>
+                </div>
+              ))
+            ) : (
+              <div className="p-8 bg-gray-25 rounded-lg">
+                <p className="text-body text-gray-600 text-center">
+                  아직 작성된 리뷰가 없습니다.
+                </p>
+              </div>
+            )}
+          </div>
+          
+          {/* Pagination */}
+          {reviews.length > 0 && totalPages > 1 && (
+            <div className="flex justify-center">
+              <Pagination 
+                currentPage={currentPage}
+                totalPages={totalPages}
+                onPageChange={setCurrentPage}
+              />
+            </div>
+          )}
+        </>
+      ) : (
+        <div className="p-8 bg-gray-25 rounded-lg">
+          <p className="text-body text-gray-600 text-center">
+            아직 작성된 리뷰가 없습니다.
+          </p>
         </div>
       )}
     </div>
   );
 };
 
-// 후기 별 아이콘 컴포넌트
+// 별 아이콘 컴포넌트
 const Star = ({ filled, size = "normal" }: { filled: boolean; size?: string }) => {
   const sizeClass = size === "small" ? "w-4 h-4" : "w-6 h-6";
   const color = filled ? "#FFC107" : "#E0E0E5";

--- a/src/features/public/services/activities.ts
+++ b/src/features/public/services/activities.ts
@@ -1,0 +1,22 @@
+import { ActivityData } from '@/src/types/activityType';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL;
+
+/**
+ * 체험 상세 정보 조회
+ */
+export const getActivityDetail = async (activityId: string): Promise<ActivityData> => {
+  const response = await fetch(`${API_BASE_URL}/activities/${activityId}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error('체험 상세 정보를 가져오는데 실패했습니다.');
+  }
+
+  const data = await response.json();
+  return data;
+};

--- a/src/types/activityType.ts
+++ b/src/types/activityType.ts
@@ -1,19 +1,46 @@
-import { Coordinates } from '@/src/types/kakaoMapType';
-import { Review } from '@/src/types/reviewType';
+import { Coordinates } from './kakaoMapType';
+import { Review } from './reviewType';
 
-// 체험 상세 데이터 타입
+// 스케줄 시간대 타입
+export interface ScheduleTime {
+  id: number;
+  startTime: string;
+  endTime: string;
+}
+
+// 스케줄 타입
+export interface Schedule {
+  date: string;
+  times: ScheduleTime[];
+}
+
+// 서브 이미지 타입
+export interface SubImage {
+  id: number;
+  imageUrl: string;
+}
+
+// 체험 상세 데이터 타입 (API 응답)
 export interface ActivityData {
-  category: string;
+  id: number;
+  userId: number;
   title: string;
+  description: string;
+  category: string;
+  price: number;
+  address: string;
+  bannerImageUrl: string;
   rating: number;
   reviewCount: number;
-  location: string;
-  address: string;
-  price: number;
-  description: string;
-  bannerImageUrl: string | null;
-  subImages: string[];
-  availableTimes: string[];
-  coordinates: Coordinates;
-  reviews: Review[];
+  createdAt: string;
+  updatedAt: string;
+  schedules: Schedule[];
+  subImages: SubImage[];
+}
+
+// 페이지에서 사용할 확장 타입
+export interface ActivityDetailData extends ActivityData {
+  location?: string;
+  coordinates?: Coordinates;
+  reviews?: Review[];
 }

--- a/src/types/kakaoMapType.ts
+++ b/src/types/kakaoMapType.ts
@@ -20,11 +20,28 @@ export interface KakaoMap {
   setLevel(level: number): void;
 }
 
+export interface KakaoGeocoder {
+  addressSearch(
+    address: string,
+    callback: (result: Array<{ x: string; y: string }>, status: string) => void
+  ): void;
+}
+
+export interface KakaoServices {
+  Status: {
+    OK: string;
+    ZERO_RESULT: string;
+    ERROR: string;
+  };
+  Geocoder: new () => KakaoGeocoder;
+}
+
 export interface KakaoMaps {
   LatLng: new (lat: number, lng: number) => KakaoLatLng;
   Map: new (container: HTMLElement, options: { center: KakaoLatLng; level: number }) => KakaoMap;
   Marker: new (options: { position: KakaoLatLng }) => KakaoMarker;
   load(callback: () => void): void;
+  services: KakaoServices;
 }
 
 export interface Kakao {


### PR DESCRIPTION
## 📌 PR 개요

- 이 PR이 어떤 목적을 가지고 있는지 간단히 설명해주세요.
- 체험 상세 페이지 내용 중 기본적인 등록시에 등록되는 체험 내용 소개 등 받아오기.
- 테스트 한답시고 하기는 했으나, 스웨거에서 직접 생성하여 급하게 테스트를 하다보니 이상한 부분 있을 수 있음.

## 🔍 관련 이슈

- Closes #201 
  (ex. Closes #12)

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [x] ✨ feat (새 기능 추가)
- [] 🐛 fix (버그 수정)
- [x] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [x] ♻️ refactor (리팩토링)
- [x] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- 주요 변경 내용을 리스트로 정리해주세요.
- 기존 카카오맵만 적용된 것을 카카오맵이 좌표를 기준으로 위치를 내보내서 주소를 좌표로 변경하도록 함. (카카오 맵 관련 공식 문서 참고)
- 체험 등록시 등록된 주소에 맞게 지도 표시
- 기본적인 체험 상세 정보 조회 api를 받아˗ˋˏ 와 ˎˊ˗서  제목, 설명, 카테고리, 가격, 주소, 배너 이미지, 서브 이미지, 스케줄(시간/날짜), 평점/리뷰 수 받아옴

`ex`

- 로그인 API 연동 (`/api/login`) 추가
- 로그인 폼에서 이메일/비밀번호 유효성 검사 로직 추가
- 로그인 성공 시 JWT 토큰을 localStorage에 저장하도록 수정
- UI: 로그인 버튼 클릭 시 로딩 스피너 추가

## 📝 PR 제목 규칙

PR 제목은 커밋 컨벤션을 따라야 합니다.  
ex) feat: 롤링페이퍼 작성 기능 추가 (#15)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

https://github.com/user-attachments/assets/dd8fb710-33db-40c9-b05d-c8c8b2ac456c


- UI 변경이 있다면 캡처 이미지 첨부

## 🤝 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 맥락(설계 의도, 제약사항 등)
- 리저베이션 컴포넌트 (예약 캘린더)에 시간은 다른 api를 연동해야 해서 현재 그거까진 불러오지 못 함
- 이미지를 제대로 안 정하고 실제 이미지를 넣은게 아니므로 깨져 보이는게 정상임 배치 순서는 다음 PR 올리면서 정리할 예정.
- 이미지를 가져오면서 이전 사이드 메뉴 프로필 이미지 변경 적용 할 때 nextconfig 파일에 이미지 항목 추가한 거 이용
- 현재 pr 머지 후 다음 api연동 올릴 예정
