### PR TITLE
feat:체험 상세 예약 캘린더 api 연동 및 예약 승인 버튼api (#206)

### DIFF
--- a/src/app/activities/[activityId]/page.tsx
+++ b/src/app/activities/[activityId]/page.tsx
@@ -56,11 +56,6 @@ const ActivityDetailPage = () => {
     );
   }
 
-  // availableTimes 변환 (첫 번째 스케줄의 시간대만 사용)
-  const availableTimes = activityData.schedules?.[0]?.times?.map(
-    time => `${time.startTime}~${time.endTime}`
-  ) || [];
-
   // subImages URL 배열로 변환
   const subImageUrls = activityData.subImages?.map(img => img.imageUrl) || [];
 
@@ -69,7 +64,7 @@ const ActivityDetailPage = () => {
       <div className="max-w-[1200px] mx-auto px-6 py-8">
         <div className="grid grid-cols-1 lg:grid-cols-[1fr_350px] gap-8">
           
-          {/* 왼쪽: 이미지 및 상세 정보 */}
+          {/* 이미지 및 상세 정보 */}
           <div className="space-y-8">
             <ImageGallery 
               bannerImage={activityData.bannerImageUrl}
@@ -86,7 +81,7 @@ const ActivityDetailPage = () => {
             />
           </div>
           
-          {/* 오른쪽: 헤더 + 예약 카드 */}
+          {/* 제목 + 예약 달력 */}
           <div className="space-y-4">
             <div className="flex items-start justify-between">
               <div className="flex-1">
@@ -114,8 +109,8 @@ const ActivityDetailPage = () => {
             </p>
             
             <ReservationCard 
+              activityId={activityData.id.toString()}
               pricePerPerson={activityData.price}
-              availableTimes={availableTimes}
             />
           </div>
         </div>
@@ -329,7 +324,7 @@ const ReviewSection = ({ rating, reviewCount, reviews }: { rating: number; revie
       {reviewCount > 0 ? (
         <>
           <div className="flex flex-col items-center justify-center py-6">
-            <div className="text-[32px] font-bold text-gray-900 leading-none mb-2">
+            <div className="text-h1 font-bold text-gray-900 leading-none mb-2">
               {rating}
             </div>
             <div className="text-body-lg font-bold text-gray-900 mb-2">
@@ -375,7 +370,7 @@ const ReviewSection = ({ rating, reviewCount, reviews }: { rating: number; revie
             )}
           </div>
           
-          {/* Pagination */}
+          {/* 페이지 네이션 */}
           {reviews.length > 0 && totalPages > 1 && (
             <div className="flex justify-center">
               <Pagination 
@@ -411,16 +406,16 @@ const Star = ({ filled, size = "normal" }: { filled: boolean; size?: string }) =
 };
 
 // 예약 카드
-const ReservationCard = ({ pricePerPerson, availableTimes }: { pricePerPerson: number; availableTimes: string[] }) => {
+const ReservationCard = ({ activityId, pricePerPerson }: { activityId: string; pricePerPerson: number }) => {
   return (
     <div 
       className="bg-white rounded-lg p-4" 
       style={{ boxShadow: '0px 4px 24px 0px rgba(156, 180, 202, 0.2)' }}
     >
-      <div className="[&>*]:!text-body [&_h3]:!text-body-lg [&_button]:!text-body [&_span]:!text-body [&>*]:!border-0">
+      <div className="[&>*]:!text-body [&_h3]:!text-body-lg [&_span]:!text-body">
         <Reservation 
+          activityId={activityId}
           pricePerPerson={pricePerPerson}
-          availableTimes={availableTimes}
         />
       </div>
     </div>

--- a/src/app/api/activities/[activityId]/reservations/route.ts
+++ b/src/app/api/activities/[activityId]/reservations/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL;
+
+/**
+ * → 예약 신청
+ */
+export async function POST(
+  req: NextRequest,
+  context: { params: Promise<{ activityId: string }> }
+) {
+  const { activityId } = await context.params;
+
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get("accessToken")?.value;
+
+  if (!accessToken) {
+    return NextResponse.json(
+      { message: "로그인이 필요합니다." },
+      { status: 401 }
+    );
+  }
+
+  const body = await req.json();
+
+  const res = await fetch(`${API_URL}/activities/${activityId}/reservations`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/src/app/dev/hyeonsung/page.tsx
+++ b/src/app/dev/hyeonsung/page.tsx
@@ -198,7 +198,7 @@ export default function Home() {
         <section>
           <h2 className="text-xl font-bold text-gray-900 mb-4">캘린더 컴포넌트 테스트</h2>
           <div className="flex justify-center">
-            <Calendar />
+            <Calendar activityId="1" />
           </div>
         </section>
       </main>

--- a/src/components/Reservation/Reservation.tsx
+++ b/src/components/Reservation/Reservation.tsx
@@ -1,24 +1,27 @@
 'use client';
 
 import { format } from 'date-fns';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useReservation } from '@/src/hooks/useReservation';
 import Button from '@/src/components/Button/Button';
+import CompleteModal from '@/src/components/Modal/CompleteModal';
+import { getAvailableSchedule, AvailableSchedule, AvailableTime, createReservation } from '@/src/features/public/services/activities';
 
 const DAY_LIST = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
 
-// Props 타입 정의 (API에서 받아올 데이터)
+// Props 타입 정의
 interface ReservationProps {
-  pricePerPerson?: number; // 체험 등록 페이지에서 설정한 1인당 가격
-  availableTimes?: string[]; // 체험 등록 페이지에서 설정한 예약 가능 시간대
+  activityId: string;
+  pricePerPerson?: number;
 }
 
 export default function Reservation({ 
-  pricePerPerson = 1000, // 목업 (API 연동 전까지 사용)
-  availableTimes = ['14:00~15:00', '15:00~16:00', '16:00~17:00', '17:00~18:00'] // 기본값
+  activityId,
+  pricePerPerson = 1000,
 }: ReservationProps) {
   const {
     weeks,
+    selectedDate,
     handlePrevMonth,
     handleNextMonth,
     handleSelectDate,
@@ -28,11 +31,60 @@ export default function Reservation({
     getFormattedMonthYear,
   } = useReservation();
 
+  const [currentDate, setCurrentDate] = useState(new Date());
   const [attendees, setAttendees] = useState(1);
-  const [selectedTime, setSelectedTime] = useState<string | null>(availableTimes[0] || null);
+  const [selectedTime, setSelectedTime] = useState<string | null>(null);
+  const [selectedScheduleId, setSelectedScheduleId] = useState<number | null>(null);
   const [hasSelectedDate, setHasSelectedDate] = useState(false);
+  const [availableSchedules, setAvailableSchedules] = useState<AvailableSchedule[]>([]);
+  const [availableTimes, setAvailableTimes] = useState<AvailableTime[]>([]);
+  const [isLoadingSchedule, setIsLoadingSchedule] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const totalPrice = pricePerPerson * attendees;
+
+  // 월 변경 시 일정 조회
+  useEffect(() => {
+    const fetchSchedule = async () => {
+      try {
+        setIsLoadingSchedule(true);
+        const year = format(currentDate, 'yyyy');
+        const month = format(currentDate, 'MM');
+        
+        const schedules = await getAvailableSchedule(activityId, year, month);
+        setAvailableSchedules(schedules);
+      } catch (error) {
+        console.error('예약 가능 일정 조회 실패:', error);
+        setAvailableSchedules([]);
+      } finally {
+        setIsLoadingSchedule(false);
+      }
+    };
+
+    if (activityId) {
+      fetchSchedule();
+    }
+  }, [currentDate, activityId]);
+
+  // 날짜 선택 시 해당 날짜의 예약 가능 시간대 업데이트
+  useEffect(() => {
+    if (selectedDate) {
+      const formattedDate = format(selectedDate, 'yyyy-MM-dd');
+      const schedule = availableSchedules.find(s => s.date === formattedDate);
+      
+      if (schedule && schedule.times.length > 0) {
+        setAvailableTimes(schedule.times);
+        // 첫 번째 시간대 자동 선택
+        setSelectedTime(`${schedule.times[0].startTime}~${schedule.times[0].endTime}`);
+        setSelectedScheduleId(schedule.times[0].id);
+      } else {
+        setAvailableTimes([]);
+        setSelectedTime(null);
+        setSelectedScheduleId(null);
+      }
+    }
+  }, [selectedDate, availableSchedules]);
 
   const handleIncreaseAttendees = () => setAttendees((prev) => prev + 1);
   const handleDecreaseAttendees = () => {
@@ -44,144 +96,219 @@ export default function Reservation({
     setHasSelectedDate(true);
   };
 
+  // 이전 달로 이동
+  const goToPrevMonth = () => {
+    handlePrevMonth();
+    setCurrentDate(prev => new Date(prev.getFullYear(), prev.getMonth() - 1, 1));
+  };
+
+  // 다음 달로 이동
+  const goToNextMonth = () => {
+    handleNextMonth();
+    setCurrentDate(prev => new Date(prev.getFullYear(), prev.getMonth() + 1, 1));
+  };
+
+  // 해당 날짜에 예약 가능한 시간이 있는지 확인
+  const hasAvailableTime = (date: Date) => {
+    if (!date) return false;
+    
+    const formattedDate = format(date, 'yyyy-MM-dd');
+    const schedule = availableSchedules.find(s => s.date === formattedDate);
+    const hasTime = schedule && schedule.times.length > 0;
+    
+    return hasTime;
+  };
+
+  // 예약하기
+  const handleReservation = async () => {
+    if (!selectedDate) {
+      alert('날짜를 선택해주세요.');
+      return;
+    }
+    if (!selectedScheduleId) {
+      alert('시간을 선택해주세요.');
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+      await createReservation(activityId, {
+        scheduleId: selectedScheduleId,
+        headCount: attendees,
+      });
+      setIsModalOpen(true);
+    } catch (error) {
+      console.error('예약 실패:', error);
+      alert('예약에 실패했습니다. 다시 시도해주세요.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
   return (
-    <div className="w-full bg-white p-0">
-      {/* 가격 */}
-      <div className="mb-4">
-        <span className="text-h2 font-bold text-gray-900 tracking-h2">₩ {pricePerPerson.toLocaleString()}</span>
-        <span className="text-gray-600 ml-1 text-h3 font-medium">/ 인</span>
-      </div>
+    <>
+      <div className="w-full bg-white p-0">
+        {/* 가격 */}
+        <div className="mb-4">
+          <span className="text-h2 font-bold text-gray-900 tracking-h2">₩ {pricePerPerson.toLocaleString()}</span>
+          <span className="text-gray-600 ml-1 text-h3 font-medium">/ 인</span>
+        </div>
 
-      {/* 날짜 섹션 */}
-      <div className="mb-4">
-        <h3 className="text-body-lg font-bold text-gray-900 mb-3">날짜</h3>
+        {/* 날짜 선택 */}
+        <div className="mb-4">
+          <h3 className="text-body-lg font-bold text-gray-900 mb-3">날짜</h3>
 
-        {/* 월/년도 헤더 */}
-        <div className="flex justify-between items-center mb-3">
-          <span className="text-body-lg font-medium text-gray-900">
-            {getFormattedMonthYear()}
-          </span>
-          <div className="flex gap-3">
-            <button
-              onClick={handlePrevMonth}
-              className="w-5 h-5 flex items-center justify-center text-gray-900 hover:text-gray-600"
-            >
-              ◀
-            </button>
-            <button
-              onClick={handleNextMonth}
-              className="w-5 h-5 flex items-center justify-center text-gray-900 hover:text-gray-600"
-            >
-              ▶
-            </button>
+          {/* 월 네비게이션 */}
+          <div className="flex justify-between items-center mb-3">
+            <span className="text-body-lg font-medium text-gray-900">
+              {getFormattedMonthYear()}
+            </span>
+            <div className="flex gap-3">
+              <button
+                onClick={goToPrevMonth}
+                className="w-5 h-5 flex items-center justify-center text-gray-900 hover:text-gray-600"
+              >
+                &lt;
+              </button>
+              <button
+                onClick={goToNextMonth}
+                className="w-5 h-5 flex items-center justify-center text-gray-900 hover:text-gray-600"
+              >
+                &gt;
+              </button>
+            </div>
+          </div>
+
+          {/* 요일 헤더 */}
+          <div className="grid grid-cols-7 gap-1 mb-2">
+            {DAY_LIST.map((day, index) => (
+              <div key={index} className="text-center text-body-lg font-semibold text-gray-600">
+                {day}
+              </div>
+            ))}
+          </div>
+
+          {/* 날짜 그리드 */}
+          <div className="space-y-1">
+            {weeks.map((week, weekIndex) => (
+              <div key={weekIndex} className="grid grid-cols-7 gap-1">
+                {week.map((day, dayIndex) => {
+                  const isTodayDate = day && isToday(day);
+                  const isSelectedDate = day && hasSelectedDate && isSelected(day);
+                  const isOtherMonth = day && !isCurrentMonth(day);
+                  const isAvailable = day && !isOtherMonth && hasAvailableTime(day);
+
+                  return (
+                    <button
+                      key={dayIndex}
+                      onClick={() => day && !isOtherMonth && isAvailable && handleDateSelect(day)}
+                      disabled={!day || isOtherMonth || !isAvailable}
+                      className={`
+                        aspect-square flex items-center justify-center rounded-full text-body-lg font-medium
+                        transition-colors
+                        ${!day ? 'invisible' : ''}
+                        ${isOtherMonth ? 'text-gray-300 cursor-default' : ''}
+                        ${!isOtherMonth && !isAvailable ? 'text-gray-300 cursor-not-allowed' : ''}
+                        ${!isOtherMonth && isAvailable && !isSelectedDate ? 'text-gray-900 hover:bg-gray-50' : ''}
+                        ${isTodayDate && !isSelectedDate ? 'bg-primary-100 text-primary-500' : ''}
+                        ${isSelectedDate ? 'bg-primary-500 text-white' : ''}
+                      `}
+                    >
+                      {day ? format(day, 'd') : ''}
+                    </button>
+                  );
+                })}
+              </div>
+            ))}
           </div>
         </div>
 
-        {/* 요일 헤더 */}
-        <div className="grid grid-cols-7 gap-1 mb-2">
-          {DAY_LIST.map((day, index) => (
-            <div key={index} className="text-center text-body-lg font-semibold text-gray-600">
-              {day}
+        {/* 참여 인원수 */}
+        <div className="mb-4">
+          <div className="flex justify-between items-center">
+            <h3 className="text-body-lg font-bold text-gray-900">참여 인원수</h3>
+            <div className="flex items-center gap-2 border border-gray-200 rounded-full px-4 py-1">
+              <button
+                onClick={handleDecreaseAttendees}
+                disabled={attendees <= 1}
+                className="w-8 h-8 flex items-center justify-center bg-white text-gray-900 text-body-lg font-bold hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed"
+              >
+                -
+              </button>
+              <span className="text-body-lg font-bold text-gray-900 min-w-[28px] text-center">
+                {attendees}
+              </span>
+              <button
+                onClick={handleIncreaseAttendees}
+                className="w-8 h-8 flex items-center justify-center bg-white text-gray-900 text-body-lg font-bold hover:bg-gray-50"
+              >
+                +
+              </button>
             </div>
-          ))}
+          </div>
         </div>
 
-        {/* 날짜 그리드 */}
-        <div className="space-y-1">
-          {weeks.map((week, weekIndex) => (
-            <div key={weekIndex} className="grid grid-cols-7 gap-1">
-              {week.map((day, dayIndex) => {
-                const isTodayDate = isToday(day);
-                const isSelectedDate = hasSelectedDate && isSelected(day);
-                const isOtherMonth = !isCurrentMonth(day);
-
+        {/* 예약 가능한 시간 */}
+        <div className="mb-4">
+          <h3 className="text-body-lg font-bold text-gray-900 mb-3">예약 가능한 시간</h3>
+          <div className="space-y-2">
+            {isLoadingSchedule ? (
+              <div className="text-center text-body text-gray-600 py-4">
+                로딩 중...
+              </div>
+            ) : availableTimes.length > 0 ? (
+              availableTimes.map((time) => {
+                const timeString = `${time.startTime}~${time.endTime}`;
                 return (
                   <button
-                    key={dayIndex}
-                    onClick={() => !isOtherMonth && handleDateSelect(day)}
-                    disabled={isOtherMonth}
+                    key={time.id}
+                    onClick={() => {
+                      setSelectedTime(timeString);
+                      setSelectedScheduleId(time.id);
+                    }}
                     className={`
-                      aspect-square flex items-center justify-center rounded-full text-body-lg font-bold
-                      transition-colors
-                      ${isOtherMonth ? 'text-gray-300 cursor-default' : 'text-gray-900 hover:bg-gray-50'}
-                      ${isTodayDate && !isSelectedDate ? 'bg-primary-100 text-primary-500' : ''}
-                      ${isSelectedDate ? 'bg-primary-500 text-white' : ''}
+                      w-full py-3 px-4 rounded-[11px] text-center
+                      ${selectedTime === timeString 
+                        ? 'bg-primary-100 border-2 border-primary-500 text-primary-500 text-body-lg font-bold' 
+                        : 'bg-white border border-gray-200 text-gray-900 text-body font-medium hover:bg-gray-50'}
                     `}
                   >
-                    {format(day, 'd')}
+                    {timeString}
                   </button>
                 );
-              })}
-            </div>
-          ))}
-        </div>
-      </div>
-
-      {/* 참여 인원수 */}
-      <div className="mb-4">
-        <div className="flex justify-between items-center">
-          <h3 className="text-body-lg font-bold text-gray-900">참여 인원수</h3>
-          <div className="flex items-center gap-2 border border-gray-200 rounded-full px-4 py-1">
-            <button
-              onClick={handleDecreaseAttendees}
-              disabled={attendees <= 1}
-              className="w-8 h-8 flex items-center justify-center bg-white text-gray-900 text-body-lg font-bold hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed"
-            >
-              −
-            </button>
-            <span className="text-body-lg font-bold text-gray-900 min-w-[28px] text-center">
-              {attendees}
-            </span>
-            <button
-              onClick={handleIncreaseAttendees}
-              className="w-8 h-8 flex items-center justify-center bg-white text-gray-900 text-body-lg font-bold hover:bg-gray-50"
-            >
-              +
-            </button>
+              })
+            ) : (
+              <div className="text-center text-body text-gray-600 py-4">
+                {hasSelectedDate ? '선택한 날짜에 예약 가능한 시간이 없습니다.' : '날짜를 선택해주세요.'}
+              </div>
+            )}
           </div>
         </div>
-      </div>
 
-      {/* 예약 가능한 시간 */}
-      <div className="mb-4">
-        <h3 className="text-body-lg font-bold text-gray-900 mb-3">예약 가능한 시간</h3>
-        <div className="space-y-2">
-          {availableTimes.map((time) => (
-            <button
-              key={time}
-              onClick={() => setSelectedTime(time)}
-              className={`
-                w-full h-12 rounded-lg border text-body-lg font-medium transition-colors
-                ${
-                  selectedTime === time
-                    ? 'bg-primary-100 border-primary-500 text-primary-500'
-                    : 'bg-white border-gray-200 text-gray-900 hover:border-gray-300'
-                }
-              `}
-            >
-              {time}
-            </button>
-          ))}
+        {/* 총 합계 및 예약하기 */}
+        <div className="flex justify-between items-center pt-3 border-t border-gray-200">
+          <div className="flex items-baseline gap-2">
+            <span className="text-h3 font-medium text-gray-600">총 합계</span>
+            <span className="text-h3 font-bold text-gray-900 tracking-h3">
+              ₩ {totalPrice.toLocaleString()}
+            </span>
+          </div>
+          <Button
+            onClick={handleReservation}
+            variant="primary"
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? '처리 중...' : '예약하기'}
+          </Button>
         </div>
       </div>
 
-      {/* 하단 예약하기 */}
-      <div className="flex justify-between items-center pt-3 border-t border-gray-200">
-        <div className="flex items-baseline gap-2">
-          <span className="text-h3 font-medium text-gray-600">총 합계</span>
-          <span className="text-h3 font-bold text-gray-900 tracking-h3">
-            ₩ {totalPrice.toLocaleString()}
-          </span>
-        </div>
-        <Button
-          variant="primary"
-          size="md"
-          disabled={!hasSelectedDate}
-          onClick={() => alert('예약 완료!')}
-        >
-          예약하기
-        </Button>
-      </div>
-    </div>
+      {/* 예약 완료 모달 */}
+      <CompleteModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        message="예약이 완료되었습니다."
+      />
+    </>
   );
 }

--- a/src/features/public/services/activities.ts
+++ b/src/features/public/services/activities.ts
@@ -20,3 +20,92 @@ export const getActivityDetail = async (activityId: string): Promise<ActivityDat
   const data = await response.json();
   return data;
 };
+
+/**
+ * 예약 가능 일정 조회
+ */
+export interface AvailableTime {
+  id: number;
+  startTime: string;
+  endTime: string;
+}
+
+export interface AvailableSchedule {
+  date: string;
+  times: AvailableTime[];
+}
+
+export const getAvailableSchedule = async (
+  activityId: string,
+  year: string,
+  month: string
+): Promise<AvailableSchedule[]> => {
+  const response = await fetch(
+    `${API_BASE_URL}/activities/${activityId}/available-schedule?year=${year}&month=${month}`,
+    {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error('예약 가능 일정을 가져오는데 실패했습니다.');
+  }
+
+  const data = await response.json();
+  return data;
+};
+
+/**
+ * 예약 신청 요청 타입
+ */
+export interface CreateReservationRequest {
+  scheduleId: number;
+  headCount: number;
+}
+
+/**
+ * 예약 신청 응답 타입
+ */
+export interface ReservationResponse {
+  id: number;
+  teamId: string;
+  userId: number;
+  activityId: number;
+  scheduleId: number;
+  status: 'pending' | 'confirmed' | 'declined' | 'canceled';
+  reviewSubmitted: boolean;
+  totalPrice: number;
+  headCount: number;
+  date: string;
+  startTime: string;
+  endTime: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * 예약 신청
+ */
+export const createReservation = async (
+  activityId: string,
+  data: CreateReservationRequest
+): Promise<ReservationResponse> => {
+  const response = await fetch(`/api/activities/${activityId}/reservations`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+  });
+
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(error.message || '예약 신청에 실패했습니다.');
+  }
+
+  const result = await response.json();
+  return result;
+};


### PR DESCRIPTION
## 📌 PR 개요

- 이 PR이 어떤 목적을 가지고 있는지 간단히 설명해주세요.
- 체험 상세 페이지 내에서 등록된 시간대, 날짜를 받아오고, 그걸 기준으로 캘린더에 표시가 되도록 함. 
- 버튼도 같이 연동하여서 누르면 예약했다는 정보가 보내짐

## 🔍 관련 이슈

- Closes #206 
  (ex. Closes #12)

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [x] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [x] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- 주요 변경 내용을 리스트로 정리해주세요.
- api라우트 파일을 생성해서 서버에서 쿠키로 액세스 토큰 가져옴
- 기존 Reservation이 클라이언트 컴포넌트라 next/header를 사용 못 해서 만듬

`ex`

- 로그인 API 연동 (`/api/login`) 추가
- 로그인 폼에서 이메일/비밀번호 유효성 검사 로직 추가
- 로그인 성공 시 JWT 토큰을 localStorage에 저장하도록 수정
- UI: 로그인 버튼 클릭 시 로딩 스피너 추가

## 📝 PR 제목 규칙

PR 제목은 커밋 컨벤션을 따라야 합니다.  
ex) feat: 롤링페이퍼 작성 기능 추가 (#15)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

- UI 변경이 있다면 캡처 이미지 첨부
<img width="1087" height="598" alt="스크린샷 2026-01-15 오후 4 12 04" src="https://github.com/user-attachments/assets/0c0f9042-b9e2-4f75-a83c-84a74b7aa595" />


## 🤝 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 맥락(설계 의도, 제약사항 등)
- 두 번째 커밋으로 데브 페이지를 올렸는데, 리저베이션 컴포넌트 약간 수정 들어가면서 기존에 테스트 페이지에서 보여주던 것과 달라 타입 에러랑 빌드 에러가 발생하여 수정 후 재커밋 함.
