### PR TITLE
feat: 페이지 (내정보/체험상세) 경로 설정 및 기존 값 추가 (#220)

### DIFF
--- a/src/app/(auth)/mypage/MypageLayout.tsx
+++ b/src/app/(auth)/mypage/MypageLayout.tsx
@@ -20,9 +20,28 @@ export const useUser = () => {
   return context;
 };
 
+// 전역 핸들러
+let globalCancelHandler: (() => void) | null = null;
+
+export const setGlobalCancelHandler = (handler: () => void) => {
+  globalCancelHandler = handler;
+};
+
+export const getGlobalCancelHandler = (): (() => void) | null =>
+  globalCancelHandler;
+
 // 내부 콘텐츠 컴포넌트
 function MyPageLayoutContent({ children }: { children: React.ReactNode }) {
   const { userData, refreshUser } = useUser();
+  const [showMobileContent, setShowMobileContent] = useState(false);
+
+  const handleCancel = () => {
+    setShowMobileContent(false);
+  };
+
+  useEffect(() => {
+    setGlobalCancelHandler(handleCancel);
+  }, []);
 
   const handleProfileEdit = () => {
     const input = document.createElement('input');
@@ -45,6 +64,10 @@ function MyPageLayoutContent({ children }: { children: React.ReactNode }) {
     input.click();
   };
 
+  const handleMenuClick = () => {
+    setShowMobileContent(true);
+  };
+
   return (
     <div className="flex-1">
       {/* 헤더/푸터 사이 영역 */}
@@ -52,10 +75,16 @@ function MyPageLayoutContent({ children }: { children: React.ReactNode }) {
         <div className="w-full max-w-[980px] mx-auto px-6 h-full">
           <div className="flex gap-14 h-full">
             {/* 사이드 메뉴 */}
-            <aside className="w-[260px] flex-shrink-0">
+            <aside
+              className={`w-[260px] flex-shrink-0 ${
+                showMobileContent ? "hidden md:block" : "block"
+              }`}
+            >
               <SideMenu
                 profileImageUrl={userData?.profileImageUrl}
                 onProfileEdit={handleProfileEdit}
+                onMenuClick={handleMenuClick}
+                showMobileContent={showMobileContent}
               />
             </aside>
 

--- a/src/app/(auth)/mypage/my-profile/page.tsx
+++ b/src/app/(auth)/mypage/my-profile/page.tsx
@@ -6,11 +6,17 @@ import Button from '@/src/components/Button/Button';
 import { useMyPageForm } from '@/src/features/public/hooks/useMyPageForm';
 import { updateMyProfile } from '@/src/features/mypage/services/userService';
 import { useUser } from '@/src/app/(auth)/mypage/MypageLayout';
+import { getGlobalCancelHandler } from '@/src/app/(auth)/mypage/MypageLayout';
 
 export default function MyProfilePage() {
   const [isSaving, setIsSaving] = useState(false);
 
   const { userData, refreshUser } = useUser();
+
+  const handleMobileCancel = () => {
+    const cancelHandler = getGlobalCancelHandler();
+    if (cancelHandler) cancelHandler();
+  };
 
   // 폼 상태 관리
   const {
@@ -83,7 +89,7 @@ export default function MyProfilePage() {
 
   return (
     <div className="flex-1">
-      <div className="max-w-[640px]">
+      <div className="max-w-[640px] md:scale-[0.857] md:origin-top-left md:-mr-[90px] lg:scale-100 lg:mr-0">
         {/* 페이지 제목 */}
         <div className="mb-8">
           <h1 className="text-lg font-bold text-gray-900 mb-2">내 정보</h1>
@@ -149,7 +155,19 @@ export default function MyProfilePage() {
           </div>
 
           {/* 버튼 영역 */}
-          <div className="flex justify-center pt-6">
+          <div className="flex justify-center gap-3 pt-6">
+            {/* 취소하기 버튼 모바일에서만 */}
+            <Button
+              type="button"
+              onClick={handleMobileCancel}
+              variant="secondary"
+              size="sm"
+              className="md:hidden"
+            >
+              취소하기
+            </Button>
+
+            {/* 저장하기 버튼 */}
             <Button
               type="button"
               onClick={handleSaveClick}

--- a/src/app/activities/[activityId]/page.tsx
+++ b/src/app/activities/[activityId]/page.tsx
@@ -176,7 +176,7 @@ const KebabMenu = ({
 
   const handleEdit = () => {
     setIsOpen(false);
-    router.push('/');
+    router.push(`/seller/activities/${activityId}/edit`);
   };
 
   const handleDeleteClick = () => {
@@ -289,9 +289,11 @@ const DescriptionSection = ({ description }: { description: string }) => {
       <h2 className="text-h3 font-bold text-gray-900 tracking-h3">
         체험 설명
       </h2>
+      <div className="p-6 bg-gray-25 rounded-lg">
         <p className="text-body text-gray-700 whitespace-pre-wrap">
           {description}
         </p>
+      </div>
     </div>
   );
 };

--- a/src/features/public/hooks/useMyPageForm.ts
+++ b/src/features/public/hooks/useMyPageForm.ts
@@ -34,11 +34,11 @@ export function useMyPageForm({
   const [confirmPassword, setConfirmPassword] = useState('');
   const [confirmPasswordError, setConfirmPasswordError] = useState('');
 
-  // 초기값 저장
-  const [initialValues] = useState({
+  // 초기값 저장 - 함수형으로 개선
+  const [initialValues] = useState(() => ({
     nickname: initialNickname,
     email: initialEmail,
-  });
+  }));
 
   const handleNicknameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;


### PR DESCRIPTION
## 📌 PR 개요

- 이 PR이 어떤 목적을 가지고 있는지 간단히 설명해주세요.
- 원래 내 정보 페이지에 있던 반응형 값 (일부)추가 및 체험 상세 페이지 케밥 메뉴 경로 수정 

## 🔍 관련 이슈

- Closes #220 
- Closes #189 
  (ex. Closes #12)

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [x] ✨ feat (새 기능 추가)
- [x] 🐛 fix (버그 수정)
- [x] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [x] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [x] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- 주요 변경 내용을 리스트로 정리해주세요.

`ex`

- 로그인 API 연동 (`/api/login`) 추가
- 로그인 폼에서 이메일/비밀번호 유효성 검사 로직 추가
- 로그인 성공 시 JWT 토큰을 localStorage에 저장하도록 수정
- UI: 로그인 버튼 클릭 시 로딩 스피너 추가

## 📝 PR 제목 규칙

PR 제목은 커밋 컨벤션을 따라야 합니다.  
ex) feat: 롤링페이퍼 작성 기능 추가 (#15)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

- UI 변경이 있다면 캡처 이미지 첨부

## 🤝 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 맥락(설계 의도, 제약사항 등)
