### PR TITLE
feat: 메인 페이지 체험 리스트 API 연동 및 타입 정의 (#178)

### DIFF
--- a/src/app/(auth)/page.tsx
+++ b/src/app/(auth)/page.tsx
@@ -40,7 +40,7 @@ export default function Home() {
     }
 
     const queryString = newParams.toString();
-    router.push(queryString ? `/?${queryString}` : '/');
+    router.push(queryString ? `/?${queryString}` : '/', { scroll: false });
   };
 
   const handleSearch = (term: string) => {
@@ -70,7 +70,10 @@ export default function Home() {
         ) : (
           <div className="flex flex-col gap-16">
             <PopularActivitiesSection />
-            <AllActivitiesSection />
+            <AllActivitiesSection
+              page={currentPage}
+              onPageChange={handlePageChange}
+            />
           </div>
         )}
       </main>

--- a/src/app/(auth)/page.tsx
+++ b/src/app/(auth)/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
 import HeroSection from "@/src/features/mainpage/components/HeroSection";
 import SearchSection from "@/src/features/mainpage/components/SearchSection";
 import PopularActivitiesSection from "@/src/features/mainpage/components/PopularActivitiesSection";
@@ -8,25 +8,36 @@ import AllActivitiesSection from "@/src/features/mainpage/components/AllActiviti
 import SearchResultsSection from '@/src/features/mainpage/components/SearchResultsSection';
 
 export default function Home() {
-  const [searchTerm, setSearchTerm] = useState('');
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  const searchTerm = searchParams.get('keyword') || '';
+
+  const handleSearch = (term: string) => {
+    if (term.trim()) {
+      router.push(`/?keyword=${encodeURIComponent(term)}`);
+    } else {
+      router.push('/');
+    }
+  };
 
   return (
-    <div className="min-h-screen flex flex-col gap-15">
+    <div className="min-h-screen flex flex-col gap-16">
       <div className="bg-gradient-to-t from-white via-[#F7FBFF] to-[#BBDDFF]/50">
         <div className="w-full max-w-[1200px] mx-auto mt-[53px] px-10 py-[50px]">
           <HeroSection />
-          <SearchSection onSearch={setSearchTerm} />
-
+          <SearchSection onSearch={handleSearch} />
         </div>
       </div>
-      <main className="w-full max-w-[1200px] mx-auto px-10 py-5 flex flex-col gap-15">
+
+      <main className="w-full max-w-[1200px] mx-auto px-10 py-5 flex flex-col gap-16">
         {searchTerm ? (
           <SearchResultsSection searchTerm={searchTerm} />
         ) : (
-          <>
+          <div className="flex flex-col gap-16">
             <PopularActivitiesSection />
             <AllActivitiesSection />
-          </>
+          </div>
         )}
       </main>
     </div>

--- a/src/app/(auth)/page.tsx
+++ b/src/app/(auth)/page.tsx
@@ -12,13 +12,43 @@ export default function Home() {
   const router = useRouter();
 
   const searchTerm = searchParams.get('keyword') || '';
+  const pageParam = searchParams.get('page');
+  const currentPage = (pageParam && Number(pageParam) > 0) ? Number(pageParam) : 1;
+
+  // 공통 쿼리 업데이트 함수
+  const updateQueryParams = (params: { keyword?: string; page?: number }) => {
+    const newParams = new URLSearchParams(searchParams.toString());
+
+    // keyword 업데이트
+    if (params.keyword !== undefined) {
+      if (params.keyword.trim()) {
+        newParams.set('keyword', params.keyword);
+        newParams.delete('page');    // 검색어가 바뀌면 페이지 1로 리셋 (page 쿼리 삭제)
+      } else {
+        newParams.delete('keyword');
+        newParams.delete('page');
+      }
+    }
+
+    // page 업데이트
+    if (params.page !== undefined) {
+      if (params.page > 1) {
+        newParams.set('page', params.page.toString());
+      } else {
+        newParams.delete('page');    // 1페이지는 주소에 미표시
+      }
+    }
+
+    const queryString = newParams.toString();
+    router.push(queryString ? `/?${queryString}` : '/');
+  };
 
   const handleSearch = (term: string) => {
-    if (term.trim()) {
-      router.push(`/?keyword=${encodeURIComponent(term)}`);
-    } else {
-      router.push('/');
-    }
+    updateQueryParams({ keyword: term });
+  };
+
+  const handlePageChange = (page: number) => {
+    updateQueryParams({ page });
   };
 
   return (
@@ -32,7 +62,11 @@ export default function Home() {
 
       <main className="w-full max-w-[1200px] mx-auto px-10 py-5 flex flex-col gap-16">
         {searchTerm ? (
-          <SearchResultsSection searchTerm={searchTerm} />
+          <SearchResultsSection
+            searchTerm={searchTerm}
+            currentPage={currentPage}
+            onPageChange={handlePageChange}
+          />
         ) : (
           <div className="flex flex-col gap-16">
             <PopularActivitiesSection />

--- a/src/components/Card/ActivityCard.tsx
+++ b/src/components/Card/ActivityCard.tsx
@@ -7,10 +7,9 @@ import StarIcon from '@/assets/icon_star.svg';
 export interface ActivityCardProps {
   id: number;
   title: string;
-  rating: number;
-  reviewCount: number;
+  rating?: number;
+  reviewCount?: number;
   price: number;
-  category?: string;
   bannerImageUrl?: string;
 }
 

--- a/src/components/Card/AllActivitiesList.tsx
+++ b/src/components/Card/AllActivitiesList.tsx
@@ -2,14 +2,12 @@
 
 import ActivityCard from '@/src/components/Card/ActivityCard';
 import { Pagination } from '@/src/components/Pagination/Pagination';
-import { mockActivities } from '@/src/components/Card/MockActivities';
 import PriceSortDropdown from '@/src/components/Dropdown/PriceSortDropdown';
 import CategoryFilter from '@/src/components/Card/CategoryFilter';
 import { useActivitiesFilter } from '@/src/hooks/useActivitiesFilter';
 
 export default function AllActivitiesList() {
   const {
-    priceSort,
     selectedCategory,
     currentPage,
     setPriceSort,
@@ -18,7 +16,6 @@ export default function AllActivitiesList() {
     currentItems,
     totalPages,
   } = useActivitiesFilter({
-    activities: mockActivities,
     itemsPerPage: 8,
   });
 
@@ -37,7 +34,7 @@ export default function AllActivitiesList() {
 
         <div className="flex items-center flex-end">
           <PriceSortDropdown
-            value={priceSort || 'price_asc'}
+            value={'price_asc'}
             onChange={setPriceSort}
           />
         </div>

--- a/src/components/Card/AllActivitiesList.tsx
+++ b/src/components/Card/AllActivitiesList.tsx
@@ -1,23 +1,23 @@
 'use client';
 
 import ActivityCard from '@/src/components/Card/ActivityCard';
-import { Pagination } from '@/src/components/Pagination/Pagination';
 import PriceSortDropdown from '@/src/components/Dropdown/PriceSortDropdown';
 import CategoryFilter from '@/src/components/Card/CategoryFilter';
-import { useActivitiesFilter } from '@/src/hooks/useActivitiesFilter';
+import { Activity, SortOption } from '@/src/features/mainpage/activities';
 
-export default function AllActivitiesList() {
-  const {
-    selectedCategory,
-    currentPage,
-    setPriceSort,
-    setSelectedCategory,
-    setCurrentPage,
-    currentItems,
-    totalPages,
-  } = useActivitiesFilter({
-    itemsPerPage: 8,
-  });
+interface AllActivitiesListProps {
+  currentItems: Activity[];
+  selectedCategory: string | null;
+  setPriceSort: (sort: SortOption) => void;
+  onCategoryChange: (category: string | null) => void;
+}
+
+export default function AllActivitiesList({
+  currentItems,
+  selectedCategory,
+  setPriceSort,
+  onCategoryChange,
+}: AllActivitiesListProps) {
 
   const categories = ['문화 · 예술', '식음료', '스포츠', '투어', '관광', '웰빙'];
 
@@ -28,7 +28,7 @@ export default function AllActivitiesList() {
           <CategoryFilter
             categories={categories}
             selected={selectedCategory}
-            onSelect={setSelectedCategory}
+            onSelect={onCategoryChange}
           />
         </div>
 
@@ -44,15 +44,6 @@ export default function AllActivitiesList() {
         {currentItems.map((item) => (
           <ActivityCard key={item.id} {...item} />
         ))}
-      </div>
-
-      <div className="mt-[30px] flex justify-center">
-        <Pagination
-          currentPage={currentPage}
-          totalPages={totalPages}
-          onPageChange={setCurrentPage}
-          maxPageButtons={7}
-        />
       </div>
     </div>
   );

--- a/src/components/Card/PopularActivitiesList.tsx
+++ b/src/components/Card/PopularActivitiesList.tsx
@@ -2,18 +2,14 @@
 
 import { useEffect, useRef, useState, useCallback } from 'react';
 import ActivityCard from '@/src/components/Card/ActivityCard';
-import { getMockActivities } from '@/src/components/Card/MockActivities';
 import ArrowRightIcon from '@/src/assets/icon_arrow_right.svg';
 import ArrowLeftIcon from '@/src/assets/icon_arrow_left.svg';
+import { Activity, getPopularActivities } from '@/src/features/mainpage/activities';
 
 export default function PopularActivitiesList() {
-
-  // 초기 데이터 로드
-  const initialData = getMockActivities(0, 4);
-
-  const [items, setItems] = useState(initialData.data);
-  const [page, setPage] = useState(1);
-  const [hasMore, setHasMore] = useState(initialData.hasMore);
+  const [items, setItems] = useState<Activity[]>([]);
+  const [cursorId, setCursorId] = useState<number | null>(null);
+  const [hasMore, setHasMore] = useState(true);
   const [showLeftBtn, setShowLeftBtn] = useState(false);
   const [showRightBtn, setShowRightBtn] = useState(true);
   const [isLoading, setIsLoading] = useState(false);
@@ -33,21 +29,27 @@ export default function PopularActivitiesList() {
     setIsLoading(true);
 
     try {
-      // TODO: API 연동 시 수정 예정
-      const result = getMockActivities(page, 4);
-      if (result.data.length > 0) {
-        setItems((prevItems) => [...prevItems, ...result.data]);
-        setHasMore(result.hasMore);
-        setPage((prevPage) => prevPage + 1);
+      const result = await getPopularActivities(cursorId, 4);
+
+      if (result?.activities && result.activities.length > 0) {
+        setItems((prevItems) => [...prevItems, ...result.activities]);
+        setCursorId(result.cursorId);
+        setHasMore(result.cursorId !== null);
+      } else {
+        setHasMore(false);
       }
     } catch (error) {
       console.error("데이터 로드 실패:", error);
     } finally {
       setIsLoading(false);
     }
-  }, [page, hasMore, isLoading]);
+  }, [cursorId, hasMore, isLoading]);
 
   // 마지막 요소가 보이면 로드 - 모바일
+  useEffect(() => {
+    loadMore();
+  }, []);
+
   useEffect(() => {
     if (!hasMore || isLoading) return;
 

--- a/src/components/Card/PopularActivitiesList.tsx
+++ b/src/components/Card/PopularActivitiesList.tsx
@@ -32,7 +32,11 @@ export default function PopularActivitiesList() {
       const result = await getPopularActivities(cursorId, 4);
 
       if (result?.activities && result.activities.length > 0) {
-        setItems((prevItems) => [...prevItems, ...result.activities]);
+        setItems((prevItems) => {
+          const merged = [...prevItems, ...result.activities];
+          const map = new Map(merged.map(item => [item.id, item]));
+          return Array.from(map.values());
+        });
         setCursorId(result.cursorId);
         setHasMore(result.cursorId !== null);
       } else {

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -4,70 +4,70 @@ import React from 'react';
 import SearchIcon from '@/assets/icon_search.svg';
 
 export type SearchProps = {
-    title?: string;                     // 상단 타이틀 제목
-    value: string;                      // 현재 입력된 검색어
-    onChange: (value: string) => void;  // 검색어 변경 시 호출되는 함수
-    onSearch?: (value: string) => void; // 검색 시 호출되는 함수
-    placeholder?: string;               // 입력 필드의 플레이스홀더 텍스트
-    className?: string;                 // 추가적인 CSS 클래스 이름
+  title?: string;                     // 상단 타이틀 제목
+  value: string;                      // 현재 입력된 검색어
+  onChange: (value: string) => void;  // 검색어 변경 시 호출되는 함수
+  onSearch?: (value: string) => void; // 검색 시 호출되는 함수
+  placeholder?: string;               // 입력 필드의 플레이스홀더 텍스트
+  className?: string;                 // 추가적인 CSS 클래스 이름
 };
 
 export default function Search({
-    title = '무엇을 체험하고 싶으신가요?',
-    value,
-    onChange,
-    onSearch,
-    placeholder = '내가 원하는 체험은',
-    className = '',
+  title = '무엇을 체험하고 싶으신가요?',
+  value,
+  onChange,
+  onSearch,
+  placeholder = '내가 원하는 체험은',
+  className = '',
 }: SearchProps) {
 
-    // Enter 키 입력 시 검색
-    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-        if (e.key === 'Enter') {
-            onSearch?.(value.trim());
-        }
-    };
+  // Enter 키 입력 시 검색
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      onSearch?.(value.trim());
+    }
+  };
 
-    // 검색 버튼 클릭 시 검색
-    const handleSearch = () => {
-        onSearch?.(value.trim());
-    };
+  // 검색 버튼 클릭 시 검색
+  const handleSearch = () => {
+    onSearch?.(value.trim());
+  };
 
-    return (
-        <div className={`flex flex-col items-center gap-9 px-10 py-9 ${className}`}>
+  return (
+    <div className={`flex flex-col items-center gap-9 px-10 py-9 ${className}`}>
 
-            {/* 상단 타이틀 */}
-            {title && (
-                <h1 className="text-h1 weight-bold text-gray-950">
-                    {title}
-                </h1>
-            )}
+      {/* 상단 타이틀 */}
+      {title && (
+        <h1 className="text-h1 font-bold text-gray-950">
+          {title}
+        </h1>
+      )}
 
-            {/* 검색 입력 필드 */}
-            <div className="flex flex-row justify-between w-full items-center pl-8 pr-3 py-[10px]
+      {/* 검색 입력 필드 */}
+      <div className="flex flex-row justify-between w-full items-center pl-8 pr-3 py-[10px]
                 border border-transparent focus-within:border-primary-500 rounded-[24px] shadow-[0_4px_12px_rgba(0,0,0,0.05)]">
 
-                <div className="flex flex-row gap-[10px] items-center w-full">
-                    <SearchIcon className="w-6 h-6 text-gray-950"/>
-                    <input 
-                        type="text"
-                        value={value}
-                        onChange={(e) => onChange(e.target.value)}
-                        onKeyDown={handleKeyDown}
-                        placeholder={placeholder}
-                        className="w-full placeholder:text-gray-500 text-gray-950 text-h4 tracking-h4 weight-medium 
+        <div className="flex flex-row gap-[10px] items-center w-full">
+          <SearchIcon className="w-6 h-6 text-gray-950" />
+          <input
+            type="text"
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={placeholder}
+            className="w-full placeholder:text-gray-500 text-gray-950 text-h4 tracking-h4 weight-medium 
                                 caret-primary-500 focus:placeholder:text-transparent outline-none"
-                    />
-                </div>
-
-                <button
-                    type="button"
-                    onClick={handleSearch}
-                    className="h-[50px] w-[120px] bg-primary-500 text-white text-body-lg text-center rounded-[14px] weight-medium cursor-pointer flex items-center justify-center"
-                    >
-                    검색하기
-                </button>
-            </div>
+          />
         </div>
-    )
+
+        <button
+          type="button"
+          onClick={handleSearch}
+          className="h-[50px] w-[120px] bg-primary-500 text-white text-body-lg text-center rounded-[14px] weight-medium cursor-pointer flex items-center justify-center"
+        >
+          검색하기
+        </button>
+      </div>
+    </div>
+  )
 }

--- a/src/features/mainpage/activities.ts
+++ b/src/features/mainpage/activities.ts
@@ -55,8 +55,8 @@ export const getActivities = async ({
   sort = 'latest',
 }: GetActivitiesParams): Promise<ActivityResponse> => {
 
-  const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || '';
-  const url = `${BASE_URL}/activities`;
+  const API_URL = process.env.NEXT_PUBLIC_API_URL || '';
+  const url = `${API_URL}/activities`;
 
   const params = new URLSearchParams({
     method,

--- a/src/features/mainpage/activities.ts
+++ b/src/features/mainpage/activities.ts
@@ -1,0 +1,79 @@
+// 체험 데이터 타입
+export interface Activity {
+  id: number;
+  userId: number;
+  title: string;
+  description: string;
+  category: string;
+  price: number;
+  address: string;
+  bannerImageUrl?: string;
+  rating?: number;
+  reviewCount: number;
+  createdAt: string;
+  updatedAt?: string;
+}
+
+// 체험 리스트 응답 타입
+export interface ActivityResponse {
+  cursorId: number | null;
+  totalCount: number;
+  activities: Activity[];
+}
+
+// 체험 리스트 조회 API 파라미터 타입
+export interface GetActivitiesParams {
+  method?: 'offset' | 'cursor';
+  page?: number;
+  size?: number;
+  cursorId?: number | null;
+  keyword?: string;
+  category?: string | null;
+  sort?: SortOption;
+}
+
+export type SortOption = 'latest' | 'most_reviewed' | 'price_asc' | 'price_desc';
+
+// 인기 체험 조회
+export const getPopularActivities = async (cursorId: number | null = null, size: number = 4) => {
+  return getActivities({
+    method: 'cursor',
+    size,
+    cursorId,
+    sort: 'most_reviewed'
+  });
+};
+
+// 모든 체험 조회
+export const getActivities = async ({
+  method = 'offset',
+  page = 1,
+  size = 8,
+  cursorId = null,
+  keyword,
+  category,
+  sort = 'latest',
+}: GetActivitiesParams): Promise<ActivityResponse> => {
+
+  const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || '';
+  const url = `${BASE_URL}/activities`;
+
+  const params = new URLSearchParams({
+    method,
+    size: String(size),
+    sort,
+  });
+
+  if (method === 'offset') params.append('page', String(page));
+  if (method === 'cursor' && cursorId !== null) {
+    params.append('cursorId', String(cursorId));
+  }
+  if (keyword?.trim()) params.append('keyword', keyword);
+  if (category) params.append('category', category);
+
+  const response = await fetch(`${url}?${params.toString()}`);
+
+  if (!response.ok) throw new Error("데이터 로드 실패");
+
+  return response.json();
+};

--- a/src/features/mainpage/components/AllActivitiesSection.tsx
+++ b/src/features/mainpage/components/AllActivitiesSection.tsx
@@ -1,14 +1,13 @@
+import AllActivitiesList from "@/src/components/Card/AllActivitiesList";
+
 export default function AllActivitiesSection() {
   return (
     <section className="w-full h-[964px] flex flex-col gap-[30px]">
       <div>
         <h2 className="h-[38px] flex items-center text-h1 font-bold">🛼 모든 체험</h2>
-        <div>
-          {/* TODO: 카테고리 필터 버튼 및 드롭 다운 적용 예정 */}
-        </div>
       </div>
       <div>
-        {/* TODO: 모든 체험 리스트 적용 예정 */}
+        <AllActivitiesList />
       </div>
     </section>
   );

--- a/src/features/mainpage/components/AllActivitiesSection.tsx
+++ b/src/features/mainpage/components/AllActivitiesSection.tsx
@@ -1,14 +1,59 @@
-import AllActivitiesList from "@/src/components/Card/AllActivitiesList";
+'use client';
 
-export default function AllActivitiesSection() {
+import { useState } from 'react';
+import AllActivitiesList from '@/src/components/Card/AllActivitiesList';
+import { useActivitiesFilter } from '@/src/hooks/useActivitiesFilter';
+import { Pagination } from '@/src/components/Pagination/Pagination';
+
+interface AllActivitiesSectionProps {
+  page: number;
+  onPageChange: (page: number) => void;
+}
+
+export default function AllActivitiesSection({
+  page,
+  onPageChange,
+}: AllActivitiesSectionProps) {
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+
+  const {
+    totalPages,
+    currentItems,
+    setPriceSort,
+  } = useActivitiesFilter({
+    itemsPerPage: 8,
+    page: page,
+    selectedCategory: selectedCategory,
+  });
+
   return (
     <section className="w-full h-[964px] flex flex-col gap-[30px]">
       <div>
         <h2 className="h-[38px] flex items-center text-h1 font-bold">🛼 모든 체험</h2>
       </div>
       <div>
-        <AllActivitiesList />
+        <AllActivitiesList
+          currentItems={currentItems}
+          selectedCategory={selectedCategory}
+          setPriceSort={setPriceSort}
+          onCategoryChange={(category) => {
+            setSelectedCategory(category);
+            onPageChange(1);
+          }}
+        />
       </div>
+
+      {/* 페이지네이션 */}
+      {totalPages > 1 && (
+        <div className="mt-[30px] flex justify-center">
+          <Pagination
+            currentPage={page}
+            totalPages={totalPages}
+            onPageChange={onPageChange}
+            maxPageButtons={7}
+          />
+        </div>
+      )}
     </section>
   );
 }

--- a/src/features/mainpage/components/PopularActivitiesSection.tsx
+++ b/src/features/mainpage/components/PopularActivitiesSection.tsx
@@ -1,9 +1,11 @@
+import PopularActivitiesList from "@/src/components/Card/PopularActivitiesList";
+
 export default function PopularActivitiesSection() {
   return (
     <section className="w-full h-[366px] flex flex-col gap-5">
       <h2 className="h-[38px] flex items-center text-h1 font-bold">🔥 인기 체험</h2>
       <div>
-        {/* TODO: 인기 체험 리스트 적용 예정 */}
+        <PopularActivitiesList />
       </div>
     </section>
   );

--- a/src/features/mainpage/components/SearchResultsSection.tsx
+++ b/src/features/mainpage/components/SearchResultsSection.tsx
@@ -7,20 +7,23 @@ import EmptyImage from '@/src/assets/earth.svg';
 
 interface SearchResultsSectionProps {
   searchTerm: string;
+  currentPage: number;
+  onPageChange: (page: number) => void;
 }
 
 export default function SearchResultsSection({
   searchTerm,
+  currentPage,
+  onPageChange,
 }: SearchResultsSectionProps) {
   const {
     currentItems,
     totalPages,
     totalItems,
-    currentPage,
-    setCurrentPage,
   } = useActivitiesFilter({
     itemsPerPage: 8,
     searchTerm: searchTerm,
+    page: currentPage,
   });
 
   return (
@@ -64,7 +67,7 @@ export default function SearchResultsSection({
           <Pagination
             currentPage={currentPage}
             totalPages={totalPages}
-            onPageChange={setCurrentPage}
+            onPageChange={onPageChange}
             maxPageButtons={7}
           />
         </div>

--- a/src/features/mainpage/components/SearchResultsSection.tsx
+++ b/src/features/mainpage/components/SearchResultsSection.tsx
@@ -3,7 +3,6 @@
 import ActivityCard from '@/src/components/Card/ActivityCard';
 import { Pagination } from '@/src/components/Pagination/Pagination';
 import { useActivitiesFilter } from '@/src/hooks/useActivitiesFilter';
-import { mockActivities } from '@/src/components/Card/MockActivities';
 import EmptyImage from '@/src/assets/earth.svg';
 
 interface SearchResultsSectionProps {
@@ -20,7 +19,6 @@ export default function SearchResultsSection({
     currentPage,
     setCurrentPage,
   } = useActivitiesFilter({
-    activities: mockActivities,
     itemsPerPage: 8,
     searchTerm: searchTerm,
   });

--- a/src/hooks/useActivitiesFilter.ts
+++ b/src/hooks/useActivitiesFilter.ts
@@ -1,123 +1,90 @@
-import { useState, useMemo, useCallback } from 'react';
-import { ActivityCardProps } from '@/src/components/Card/ActivityCard';
+import { useState, useCallback, useEffect } from 'react';
+import { getActivities, Activity } from '@/src/features/mainpage/activities';
 
-export type PriceSortValue = 'price_asc' | 'price_desc';
+export type PriceSortValue = 'price_asc' | 'price_desc' | 'latest' | 'most_reviewed';
 
 interface UseActivitiesFilterProps {
-  activities: ActivityCardProps[];
   itemsPerPage: number;
   searchTerm?: string;
 }
 
-interface useActivitiesFilterReturn {
-  priceSort: PriceSortValue | null;
-  selectedCategory: string | null;
-  currentPage: number;
-  searchTerm: string;
-
-  setPriceSort: (value: PriceSortValue | null) => void;
-  setSelectedCategory: (category: string | null) => void;
-  setCurrentPage: (page: number) => void;
-  setSearchTerm: (term: string) => void;
-  resetFilters: () => void;
-
-  processedItems: ActivityCardProps[];    // 필터링 및 정렬된 전체 데이터
-  currentItems: ActivityCardProps[];      // 현재 페이지 데이터
-  totalPages: number;                     // 전체 페이지 수
-  totalItems: number;                     // 전체 데이터 수
-}
-
 export function useActivitiesFilter({
-  activities,
   itemsPerPage = 8,
   searchTerm: externalSearchTerm = '',
-}: UseActivitiesFilterProps): useActivitiesFilterReturn {
+}: UseActivitiesFilterProps) {
 
-  // 필터 상태 관리
-  const [priceSort, setPriceSort] = useState<PriceSortValue | null>(null);
-  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  // API 데이터 및 필터링 상태 관리
+  const [activities, setActivities] = useState<Activity[]>([]);
+  const [totalItems, setTotalItems] = useState(0);
   const [currentPage, setCurrentPage] = useState(1);
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [priceSort, setPriceSort] = useState<PriceSortValue>('latest');
+  const [isLoading, setIsLoading] = useState(false);
 
-  // 필터링 및 정렬된 전체 데이터
-  const processedItems = useMemo(() => {
-    let items = [...activities];
-
-    // 검색 필터링
-    if (externalSearchTerm.trim()) {
-      items = items.filter(item =>
-        item.title.toLowerCase().includes(externalSearchTerm.toLowerCase())
-      );
+  // 서버에서 데이터 불러오기
+  const fetchActivities = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const data = await getActivities({
+        method: 'offset',
+        page: currentPage,
+        size: itemsPerPage,
+        keyword: externalSearchTerm,
+        category: selectedCategory === '전체' ? null : selectedCategory,
+        sort: priceSort,
+      });
+      setActivities(data.activities);
+      setTotalItems(data.totalCount);
+    } catch (error) {
+      console.error("데이터 로드 실패:", error);
+    } finally {
+      setIsLoading(false);
     }
+  }, [currentPage, itemsPerPage, externalSearchTerm, selectedCategory, priceSort]);
 
-    // 카테고리 필터링
-    if (selectedCategory) {
-      items = items.filter(item =>
-        item.category === selectedCategory
-      );
-    }
+  // 필터 · 페이지 · 검색어 변경 시 데이터 호출
+  useEffect(() => {
+    fetchActivities();
+  }, [fetchActivities]);
 
-    // 가격 정렬
-    items.sort((a, b) => {
-      if (priceSort === null) {
-        return b.id - a.id;           // 최신 순 (ID 높은 순)
-      } else if (priceSort === 'price_asc') {
-        return a.price - b.price;    // 가격 낮은 순
-      } else {
-        return b.price - a.price;    // 가격 높은 순
-      }
-    });
-
-    return items;
-  }, [activities, externalSearchTerm, selectedCategory, priceSort]);
-
-  // 페이지네이션 계산
-  const totalPages = Math.ceil(processedItems.length / itemsPerPage);
-  const totalItems = processedItems.length;
-
-  // 현재 페이지 데이터
-  const currentItems = useMemo(() => {
-    const startIndex = (currentPage - 1) * itemsPerPage;
-    const endIndex = startIndex + itemsPerPage;
-    return processedItems.slice(startIndex, endIndex);
-  }, [processedItems, currentPage, itemsPerPage]);
-
-  // 검색어 변경 시 1페이지로 초기화
-  const handleSetSearchTerm = useCallback((term: string) => {
-    setCurrentPage(1);
-  }, []);
-
-  // 필터 변경 시 1페이지로 초기화
+  // 정렬 방식 변경 시 첫 페이지로 초기화
   const handleSetPriceSort = useCallback((sort: PriceSortValue | null) => {
-    setPriceSort(sort);
+    setPriceSort(sort || 'latest');
     setCurrentPage(1);
   }, []);
 
+  // 카테고리 변경 시 첫 페이지로 초기화
   const handleSetSelectedCategory = useCallback((category: string | null) => {
     setSelectedCategory(category);
     setCurrentPage(1);
   }, []);
 
   // 모든 필터 초기화
-  const resetFilters = () => {
-    setPriceSort(null);
+  const resetFilters = useCallback(() => {
+    setPriceSort('latest');
     setSelectedCategory(null);
     setCurrentPage(1);
-  };
+  }, []);
+
+  // 페이지네이션 계산
+  const totalPages = Math.ceil(totalItems / itemsPerPage);
 
   return {
-    searchTerm: externalSearchTerm,
+    // 필터링 상태
     priceSort,
     selectedCategory,
     currentPage,
+    searchTerm: externalSearchTerm,
+    isLoading,
 
-    setSearchTerm: handleSetSearchTerm,
+    // 상태 변경 함수
     setPriceSort: handleSetPriceSort,
     setSelectedCategory: handleSetSelectedCategory,
     setCurrentPage,
     resetFilters,
 
-    processedItems,
-    currentItems,
+    // API 응답 데이터
+    currentItems: activities,
     totalPages,
     totalItems
   };

--- a/src/hooks/useActivitiesFilter.ts
+++ b/src/hooks/useActivitiesFilter.ts
@@ -1,18 +1,18 @@
 import { useState, useCallback, useEffect } from 'react';
-import { getActivities, Activity } from '@/src/features/mainpage/activities';
-
-export type PriceSortValue = 'price_asc' | 'price_desc' | 'latest' | 'most_reviewed';
+import { getActivities, Activity, SortOption } from '@/src/features/mainpage/activities';
 
 interface UseActivitiesFilterProps {
   itemsPerPage: number;
   searchTerm?: string;
   page?: number;
+  selectedCategory?: string | null;
 }
 
 export function useActivitiesFilter({
   itemsPerPage = 8,
   searchTerm: externalSearchTerm = '',
   page = 1,
+  selectedCategory: externalCategory = null,
 }: UseActivitiesFilterProps) {
 
   // API 데이터 및 필터링 상태 관리
@@ -20,8 +20,10 @@ export function useActivitiesFilter({
   const [totalItems, setTotalItems] = useState(0);
   const [currentPage, setCurrentPage] = useState(1);
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
-  const [priceSort, setPriceSort] = useState<PriceSortValue>('latest');
+  const [priceSort, setPriceSort] = useState<SortOption>('latest');
   const [isLoading, setIsLoading] = useState(false);
+
+  const currentCategory = externalCategory !== null ? externalCategory : selectedCategory;
 
   // 서버에서 데이터 불러오기
   const fetchActivities = useCallback(async () => {
@@ -32,7 +34,7 @@ export function useActivitiesFilter({
         page: page,
         size: itemsPerPage,
         keyword: externalSearchTerm,
-        category: selectedCategory === '전체' ? null : selectedCategory,
+        category: currentCategory === '전체' ? null : currentCategory,
         sort: priceSort,
       });
       setActivities(data.activities);
@@ -42,7 +44,7 @@ export function useActivitiesFilter({
     } finally {
       setIsLoading(false);
     }
-  }, [page, itemsPerPage, externalSearchTerm, selectedCategory, priceSort]);
+  }, [page, itemsPerPage, externalSearchTerm, currentCategory, priceSort]);
 
   // 필터 · 페이지 · 검색어 변경 시 데이터 호출
   useEffect(() => {
@@ -50,7 +52,7 @@ export function useActivitiesFilter({
   }, [fetchActivities]);
 
   // 정렬 방식 변경 시 첫 페이지로 초기화
-  const handleSetPriceSort = useCallback((sort: PriceSortValue | null) => {
+  const handleSetPriceSort = useCallback((sort: SortOption | null) => {
     setPriceSort(sort || 'latest');
     setCurrentPage(1);
   }, []);
@@ -74,7 +76,7 @@ export function useActivitiesFilter({
   return {
     // 필터링 상태
     priceSort,
-    selectedCategory,
+    selectedCategory: currentCategory,
     currentPage,
     searchTerm: externalSearchTerm,
     isLoading,

--- a/src/hooks/useActivitiesFilter.ts
+++ b/src/hooks/useActivitiesFilter.ts
@@ -6,11 +6,13 @@ export type PriceSortValue = 'price_asc' | 'price_desc' | 'latest' | 'most_revie
 interface UseActivitiesFilterProps {
   itemsPerPage: number;
   searchTerm?: string;
+  page?: number;
 }
 
 export function useActivitiesFilter({
   itemsPerPage = 8,
   searchTerm: externalSearchTerm = '',
+  page = 1,
 }: UseActivitiesFilterProps) {
 
   // API 데이터 및 필터링 상태 관리
@@ -27,7 +29,7 @@ export function useActivitiesFilter({
     try {
       const data = await getActivities({
         method: 'offset',
-        page: currentPage,
+        page: page,
         size: itemsPerPage,
         keyword: externalSearchTerm,
         category: selectedCategory === '전체' ? null : selectedCategory,
@@ -40,7 +42,7 @@ export function useActivitiesFilter({
     } finally {
       setIsLoading(false);
     }
-  }, [currentPage, itemsPerPage, externalSearchTerm, selectedCategory, priceSort]);
+  }, [page, itemsPerPage, externalSearchTerm, selectedCategory, priceSort]);
 
   // 필터 · 페이지 · 검색어 변경 시 데이터 호출
   useEffect(() => {


### PR DESCRIPTION
## 📌 PR 개요

- 메인 페이지 체험 리스트 API 연동 및 타입 정의

## 🔍 관련 이슈

- Closes #178 

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [x] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [x] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- API용 체험 타입 정의
- 체험 리스트 조회 함수 분리 및 구현
  - 인기 체험 : 무한 스크롤 대응을 위한 Cursor 방식
  - 모든 체험 : 페이지네이션 대응을 위한 Offset 방식

## 📝 PR 제목 규칙

PR 제목은 커밋 컨벤션을 따라야 합니다.  
feat: 메인 페이지 체험 리스트 API 연동 및 타입 정의 (#178)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)
<img width="1905" height="2515" alt="260117-04" src="https://github.com/user-attachments/assets/55eea003-9a6b-4e11-abd3-e365bca9a52d" />

## 🤝 기타 참고 사항

- 에러 확인 
  - 체험 상세 페이지 연결 이슈 (404)
  - png 이미지 렌더링이 되지 않음
- 급한대로 올립니다..!
