### PR TITLE
feat: header에 이미지적용(#231)

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -33,6 +33,7 @@ export default function Header({ initialUser }: HeaderProps) {
           {initialUser ? (
             <LoggedInMenu
               nickname={initialUser.nickname}
+              profileImageUrl={initialUser.profileImageUrl}
               onLogout={handleLogout}
             />
           ) : (

--- a/src/components/Header/LoggedInMenu.tsx
+++ b/src/components/Header/LoggedInMenu.tsx
@@ -5,6 +5,7 @@ import BellIcon from "@/assets/icon_bell.svg";
 import DefaultProfile from "@/assets/default profile.svg";
 import Divider from "@/src/assets/divider.svg";
 import Link from "next/link";
+import Image from "next/image";
 import NotificationPanel from "@/src/components/Notification/NotificationPanel";
 import UserMenuDropDown from "../Dropdown/UserMenuDropDown";
 import { useNotifications } from "@/src/features/notification/hooks/useNotifications";
@@ -12,11 +13,13 @@ import { authFetch } from "@/src/lib/api/authFetch";
 
 type LoggedInMenuProps = {
   nickname: string;
+  profileImageUrl?: string | null;
   onLogout: () => void;
 };
 
 export default function LoggedInMenu({
   nickname,
+  profileImageUrl,
   onLogout,
 }: LoggedInMenuProps) {
   const [open, setOpen] = useState(false);
@@ -69,7 +72,20 @@ export default function LoggedInMenu({
         aria-label="마이페이지"
         className="flex items-center hover:opacity-70 transition"
       >
-        <DefaultProfile />
+        {profileImageUrl ? (
+          <div className="relative w-10 h-10 overflow-hidden rounded-full">
+            <Image
+              src={profileImageUrl}
+              alt="프로필 이미지"
+              fill
+              className="object-cover"
+              sizes="40px"
+              priority
+            />
+          </div>
+        ) : (
+          <DefaultProfile />
+        )}
       </Link>
 
       <UserMenuDropDown userName={nickname} onLogout={onLogout} />

--- a/src/lib/server/getUser.ts
+++ b/src/lib/server/getUser.ts
@@ -4,6 +4,7 @@ const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
 
 export type User = {
   nickname: string;
+  profileImageUrl?: string | null;
 };
 
 export async function getUser(): Promise<User | null> {


### PR DESCRIPTION
## 📌 PR 개요

- header에 이미지적용

## 🔍 관련 이슈

- Closes #231  

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [x] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- header에 profileImageURL props를 추가하여 이미지 설정이 없을 시 기본 이미지, 이미지 설정 시 그 이미지가 헤더에 출력되도록 구현


## 📝 PR 제목 규칙

feat: header에 이미지적용(#231)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)
<img width="1900" height="906" alt="image" src="https://github.com/user-attachments/assets/bb7d16bb-2f3f-4ecf-902f-5c7eb6d03cdb" />


## 🤝 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 맥락(설계 의도, 제약사항 등)
